### PR TITLE
Fix a small bug in model value evaluation

### DIFF
--- a/rdagent/components/coder/model_coder/CoSTEER/evaluators.py
+++ b/rdagent/components/coder/model_coder/CoSTEER/evaluators.py
@@ -47,7 +47,6 @@ def value_evaluator(
     prediction: torch.Tensor,
     target: torch.Tensor,
 ) -> Tuple[torch.Tensor, bool]:
-
     if prediction is None:
         return "No output generated from the model. Skip value evaluation", False
     elif target is None:


### PR DESCRIPTION
Value evaluation feedback does not correct. We should give different feedback when target tensor or GT tensor is not available.

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--142.org.readthedocs.build/en/142/

<!-- readthedocs-preview RDAgent end -->