### PR TITLE
fix: check if gen_df is None

### DIFF
--- a/rdagent/components/coder/factor_coder/CoSTEER/evaluators.py
+++ b/rdagent/components/coder/factor_coder/CoSTEER/evaluators.py
@@ -133,7 +133,11 @@ class FactorSingleColumnEvaluator(FactorEvaluator):
         gt_implementation: Workspace,
     ) -> Tuple[str, object]:
         _, gen_df = self._get_df(gt_implementation, implementation)
-
+        if gen_df is None:
+            return (
+                "The source dataframe is None. Please check the implementation.",
+                False,
+            )
         if len(gen_df.columns) == 1:
             return "The source dataframe has only one column which is correct.", True
         else:
@@ -241,7 +245,11 @@ class FactorRowCountEvaluator(FactorEvaluator):
         gt_implementation: Workspace,
     ) -> Tuple[str, object]:
         gt_df, gen_df = self._get_df(gt_implementation, implementation)
-
+        if gen_df is None:
+            return (
+                "The source dataframe is None. Please check the implementation.",
+                False,
+            )
         if gen_df.shape[0] == gt_df.shape[0]:
             return "Both dataframes have the same rows count.", True
         else:
@@ -258,7 +266,11 @@ class FactorIndexEvaluator(FactorEvaluator):
         gt_implementation: Workspace,
     ) -> Tuple[str, object]:
         gt_df, gen_df = self._get_df(gt_implementation, implementation)
-
+        if gen_df is None:
+            return (
+                "The source dataframe is None. Please check the implementation.",
+                False,
+            )
         if gen_df.index.equals(gt_df.index):
             return "Both dataframes have the same index.", True
         else:
@@ -275,7 +287,11 @@ class FactorMissingValuesEvaluator(FactorEvaluator):
         gt_implementation: Workspace,
     ) -> Tuple[str, object]:
         gt_df, gen_df = self._get_df(gt_implementation, implementation)
-
+        if gen_df is None:
+            return (
+                "The source dataframe is None. Please check the implementation.",
+                False,
+            )
         if gen_df.isna().sum().sum() == gt_df.isna().sum().sum():
             return "Both dataframes have the same missing values.", True
         else:
@@ -292,7 +308,11 @@ class FactorEqualValueCountEvaluator(FactorEvaluator):
         gt_implementation: Workspace,
     ) -> Tuple[str, object]:
         gt_df, gen_df = self._get_df(gt_implementation, implementation)
-
+        if gen_df is None:
+            return (
+                "The source dataframe is None. Please check the implementation.",
+                -1,
+            )
         try:
             close_values = gen_df.sub(gt_df).abs().lt(1e-6)
             result_int = close_values.astype(int)
@@ -323,7 +343,11 @@ class FactorCorrelationEvaluator(FactorEvaluator):
         gt_implementation: Workspace,
     ) -> Tuple[str, object]:
         gt_df, gen_df = self._get_df(gt_implementation, implementation)
-
+        if gen_df is None:
+            return (
+                "The source dataframe is None. Please check the implementation.",
+                False,
+            )
         concat_df = pd.concat([gen_df, gt_df], axis=1)
         concat_df.columns = ["source", "gt"]
         ic = concat_df.groupby("datetime").apply(lambda df: df["source"].corr(df["gt"])).dropna().mean()


### PR DESCRIPTION
<!--- Thank you for submitting a Pull Request! In order to make our work smoother. -->
<!--- please make sure your Pull Request meets the following requirements: -->
<!---   1. Provide a general summary of your changes in the Title above; -->
<!---   2. Add appropriate prefixes to titles, such as `build:`, `chore:`, `ci:`, `docs:`, `feat:`, `fix:`, `perf:`, `refactor:`, `revert:`, `style:`, `test:`(Ref: https://www.conventionalcommits.org/). -->
<!--- Category: -->
<!--- Patch Updates: `fix:` -->
<!---   Example: fix(auth): correct login validation issue -->
<!--- minor update (introduces new functionality): `feat` -->
<!---   Example: feature(parser): add ability to parse arrays -->
<!--- major update(destructive update): Include BREAKING CHANGE in the commit message footer, or add `! ` in the commit footer to indicate that there is a destructive update. -->
<!---   Example: feat(auth)! : remove support for old authentication method -->
<!--- Other updates: `build:`, `chore:`, `ci:`, `docs:`, `perf:`, `refactor:`, `revert:`, `style:`, `test:`. -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Are there any related issues? If so, please put the link here. -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!---  Put an `x` in all the boxes that apply: --->
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [ ] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation

Error when gen_df is None

```bash
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/root/anaconda3/envs/rdagent/lib/python3.10/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/root/remote/RD-Agent/rdagent/components/coder/factor_coder/CoSTEER/evaluators.py", line 610, in evaluate
    ) = self.value_evaluator.evaluate(implementation=implementation, gt_implementation=gt_implementation)
  File "/root/remote/RD-Agent/rdagent/components/coder/factor_coder/CoSTEER/evaluators.py", line 387, in evaluate
    feedback_str, single_column_result = FactorRowCountEvaluator(self.scen).evaluate(
  File "/root/remote/RD-Agent/rdagent/components/coder/factor_coder/CoSTEER/evaluators.py", line 249, in evaluate
    if gen_df.shape[0] == gt_df.shape[0]:
AttributeError: 'NoneType' object has no attribute 'shape'
"""
```



<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--216.org.readthedocs.build/en/216/

<!-- readthedocs-preview RDAgent end -->