### PR TITLE
feat: enable to set different version of idea-proposal for multi traces

### DIFF
--- a/rdagent/app/data_science/conf.py
+++ b/rdagent/app/data_science/conf.py
@@ -96,7 +96,8 @@ class DataScienceBasePropSetting(KaggleBasePropSetting):
 
     # enable different version of DSExpGen for multi-trace
     enable_multi_version_exp_gen: bool = False
-    
+    exp_gen_version_list: str = "v3,v2"
+
     #### multi-trace: time for final multi-trace merge
     merge_hours: int = 2
     """The time for merge"""

--- a/rdagent/app/data_science/conf.py
+++ b/rdagent/app/data_science/conf.py
@@ -91,9 +91,12 @@ class DataScienceBasePropSetting(KaggleBasePropSetting):
     # inject diverse when start a new sub-trace
     enable_inject_diverse: bool = False
 
-    # inject diverse at the root of the trace
+    # inject knowledge at the root of the trace
     enable_inject_knowledge_at_root: bool = False
 
+    # enable different version of DSExpGen for multi-trace
+    enable_multi_version_exp_gen: bool = False
+    
     #### multi-trace: time for final multi-trace merge
     merge_hours: int = 2
     """The time for merge"""
@@ -102,6 +105,7 @@ class DataScienceBasePropSetting(KaggleBasePropSetting):
     # constrains the number of SOTA experiments to retrieve, otherwise too many SOTA experiments to retrieve will cause the exceed of the context window of LLM
     max_sota_retrieved_num: int = 10
     """The maximum number of SOTA experiments to retrieve in a LLM call"""
+
 
 
 DS_RD_SETTING = DataScienceBasePropSetting()


### PR DESCRIPTION
- enable to set different version of idea-proposal for multi traces (performece test running)

- fix the logical bug to inject_knowledge in multi-tarce   (performece test on schedule)