### PR TITLE
fix: handle the bug of wrong dag_parant index

### DIFF
--- a/rdagent/scenarios/data_science/loop.py
+++ b/rdagent/scenarios/data_science/loop.py
@@ -222,8 +222,7 @@ class DataScienceRDLoop(RDLoop):
         e = prev_out.get(self.EXCEPTION_KEY, None)
         if e is None:
             exp = prev_out["running"]
-            self.trace.hist.append((exp, prev_out["feedback"]))
-
+            
             # NOTE: we put below  operations on selections here, instead of out of the if-else block,
             # to fit the corner case that the trace will be reset
 
@@ -232,19 +231,23 @@ class DataScienceRDLoop(RDLoop):
                 self.trace.set_current_selection(exp.local_selection)
             self.trace.sync_dag_parent_and_hist()
 
+            self.trace.hist.append((exp, prev_out["feedback"]))
+
         else:
             exp: DSExperiment = prev_out["direct_exp_gen"] if isinstance(e, CoderError) else prev_out["coding"]
+
+
+            # set the local selection to the trace as global selection, then set the DAG parent for the trace
+            if exp.local_selection is not None:
+                self.trace.set_current_selection(exp.local_selection)
+            self.trace.sync_dag_parent_and_hist()
+
             self.trace.hist.append(
                 (
                     exp,
                     ExperimentFeedback.from_exception(e),
                 )
             )
-
-            # set the local selection to the trace as global selection, then set the DAG parent for the trace
-            if exp.local_selection is not None:
-                self.trace.set_current_selection(exp.local_selection)
-            self.trace.sync_dag_parent_and_hist()
 
             if self.trace.sota_experiment() is None:
                 if DS_RD_SETTING.coder_on_whole_pipeline:

--- a/rdagent/scenarios/data_science/loop.py
+++ b/rdagent/scenarios/data_science/loop.py
@@ -222,7 +222,7 @@ class DataScienceRDLoop(RDLoop):
         e = prev_out.get(self.EXCEPTION_KEY, None)
         if e is None:
             exp = prev_out["running"]
-            
+
             # NOTE: we put below  operations on selections here, instead of out of the if-else block,
             # to fit the corner case that the trace will be reset
 
@@ -235,7 +235,6 @@ class DataScienceRDLoop(RDLoop):
 
         else:
             exp: DSExperiment = prev_out["direct_exp_gen"] if isinstance(e, CoderError) else prev_out["coding"]
-
 
             # set the local selection to the trace as global selection, then set the DAG parent for the trace
             if exp.local_selection is not None:


### PR DESCRIPTION
The bug was caused by the wrong calling order of "self.trace.sync_dag_parent_and_hist()" and "self.trace.hist.append" in rdagent/scenarios/data_science/loop.py, the record() method of class DataScienceRDLoop.

The correct order should be "self.trace.sync_dag_parent_and_hist()" first, then "self.trace.hist.append", but in the **feat: async mechanism for multi-trace #981**, it get inversed. Now we fix it

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--996.org.readthedocs.build/en/996/

<!-- readthedocs-preview RDAgent end -->