### PR TITLE
feat: add support for dict-type code implementations in assign_code_list_to_evo

### DIFF
--- a/rdagent/components/coder/factor_coder/evolving_strategy.py
+++ b/rdagent/components/coder/factor_coder/evolving_strategy.py
@@ -169,5 +169,16 @@ class FactorMultiProcessEvolvingStrategy(MultiProcessEvolvingStrategy):
                 continue
             if evo.sub_workspace_list[index] is None:
                 evo.sub_workspace_list[index] = FactorFBWorkspace(target_task=evo.sub_tasks[index])
-            evo.sub_workspace_list[index].inject_files(**{"factor.py": code_list[index]})
+            # code_list[index] should be either a string (for new implementations)
+            # or a dict (for existing implementations from knowledge base)
+            if isinstance(code_list[index], str):
+                # New implementation - code is a string
+                evo.sub_workspace_list[index].inject_files(**{"factor.py": code_list[index]})
+            elif isinstance(code_list[index], dict):
+                # Existing implementation - code_list[index] is already a file_dict
+                if "factor.py" not in code_list[index]:
+                    raise ValueError(f"Dictionary at code_list[{index}] must contain 'factor.py' key")
+                evo.sub_workspace_list[index].inject_files(**code_list[index])
+            else:
+                raise TypeError(f"Expected str or dict for code_list[{index}], got {type(code_list[index])}")
         return evo


### PR DESCRIPTION
## Description
Enhanced the `assign_code_list_to_evo` method to support both string and dictionary types for code implementations. The method now properly handles:
- String type: New implementations that are injected as `factor.py`
- Dictionary type: Existing implementations from knowledge base that are injected as complete file dictionaries
- Added type validation with descriptive error messages for unsupported types

## Motivation and Context
The original implementation only supported string-type code, which limited the flexibility of code injection. This enhancement allows the method to work with existing implementations from the knowledge base (dict format) as well as new implementations (string format), improving the system's ability to reuse and manage code implementations.

## How Has This Been Tested?
- [x] If you are adding a new feature, test on your own test scripts.

The enhanced method now properly handles both data types while maintaining backward compatibility with existing string-based implementations.

## Screenshots of Test Results (if appropriate):
1. Your own tests:
No screenshots needed as this is a code enhancement that extends existing functionality.

## Types of changes
- [x] Fix bugs
- [x] Add new feature
- [ ] Update documentation

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1222.org.readthedocs.build/en/1222/

<!-- readthedocs-preview RDAgent end -->