### PR TITLE
fix(docs): update rdagent ui with correct params

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ The **[🖥️ Live Demo](https://rdagent.azurewebsites.net/)** is implemented b
 - You can run the following command for our demo program to see the run logs.
 
   ```sh
-  rdagent ui --port 19899 --log-dir <your log folder like "log/"> --data_science <True or False>
+  rdagent ui --port 19899 --log-dir <your log folder like "log/"> --data-science
   ```
 
 - About the `data_science` parameter: If you want to see the logs of the data science scenario, set the `data_science` parameter to `True`; otherwise set it to `False`.


### PR DESCRIPTION
## Description

got error when running the example on README
```
$ rdagent ui --port 19899 --log-dir ./log --data_science True
Usage: rdagent ui [OPTIONS]
Try 'rdagent ui --help' for help.
╭─ Error ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ No such option: --data_science (Possible options: --data-science, --no-data-science)                                              │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```


## Screenshots of Test Results (if appropriate):
1. Your own tests:
<img width="462" height="125" alt="Screenshot 2025-09-16 at 5 20 52 PM" src="https://github.com/user-attachments/assets/eb9367f4-dc7c-4f2c-888d-28bdbd9571c4" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Fix bugs
- [ ] Add new feature
- [x] Update documentation


<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1249.org.readthedocs.build/en/1249/

<!-- readthedocs-preview RDAgent end -->