### PR TITLE
fix(dockerfile): install coreutils to resolve timeout command error

### DIFF
--- a/rdagent/scenarios/qlib/docker/Dockerfile
+++ b/rdagent/scenarios/qlib/docker/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get clean && apt-get update && apt-get install -y \
     vim \  
     git \  
     build-essential \
+    coreutils \
     && rm -rf /var/lib/apt/lists/* 
 
 RUN git clone https://github.com/microsoft/qlib.git


### PR DESCRIPTION
# Fix Dockerfile: Install coreutils to resolve timeout command issue

**Related Issue:** [#1259](https://github.com/microsoft/RD-Agent/issues/1259)

## Description
This PR fixes the error `/bin/sh: timeout: command not found` that occurs when running scripts inside the Docker container.

## Changes
- Added `coreutils` to `rdagent/scenarios/qlib/docker/Dockerfile` to provide the `timeout` command.
- Verified that `timeout` works correctly in the built container.



<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1260.org.readthedocs.build/en/1260/

<!-- readthedocs-preview RDAgent end -->