### PR TITLE
docs: add troubleshooting guide for qrun command not found error

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,23 @@
+## Troubleshooting
+
+### Error: "failed to run command 'qrun': No such file or directory"
+
+**Cause**: Qlib dependency is not properly installed.
+
+**Solution**:
+1. Install Qlib from source:
+pip install numpy
+pip install --upgrade cython
+git clone https://github.com/microsoft/qlib.git
+cd qlib
+pip install .
+
+text
+
+2. Verify installation:
+which qrun
+
+text
+
+3. Download Qlib data:
+python scripts/get_data.py qlib_data --target_dir ~/.qlib/qlib_data/cn_data --region cn


### PR DESCRIPTION
## Description
Adds troubleshooting documentation for issue #1276 where users encounter "qrun: No such file or directory" error.

## Changes
- Added troubleshooting section for qrun installation
- Included step-by-step Qlib setup instructions
- Added data download steps

## Related Issues
Fixes #1276


<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1282.org.readthedocs.build/en/1282/

<!-- readthedocs-preview RDAgent end -->