### PR TITLE
docs: add execution environment configuration guide (Docker vs Conda)

### DIFF
--- a/docs/installation_and_configuration.rst
+++ b/docs/installation_and_configuration.rst
@@ -162,25 +162,44 @@ If your `Azure OpenAI API Key`` supports `embedding model`, you can refer to the
 Execution Environment Configuration
 ===================================
 
-Model Coder Environment (Docker vs. Conda)
+Coder Environment Configuration (Docker vs. Conda)
 
-RD-Agent's model coder can execute code in different environments. You can control this behavior by setting an environment variable in your ``.env`` file. This is particularly useful for quantitative scenarios where you might want to switch between a local Conda environment and an isolated Docker container.
+RD-Agent's coders can execute code in different environments. You can control this behavior by setting environment variables in your ``.env`` file. This is useful for switching between a local Conda environment and an isolated Docker container.
+
+To configure the environment, add the corresponding line to your ``.env`` file based on the scenario you are running.
+
+**For the Model (Quant) Scenario:**
 
 The execution environment is determined by the ``MODEL_COSTEER_ENV_TYPE`` variable, which is read from ``rdagent/components/coder/model_coder/conf.py``.
 
-To configure the environment, add one of the following lines to your ``.env`` file:
+*   **To use Docker** (recommended for isolated execution):
 
-- **To use Docker** (recommended for isolated execution):
+    .. code-block:: properties
 
-  .. code-block:: properties
+       MODEL_COSTEER_ENV_TYPE=docker
 
-     MODEL_COSTEER_ENV_TYPE=docker
+*   **To use Conda** (for running in a local Conda environment):
 
-- **To use Conda** (for running in a local Conda environment):
+    .. code-block:: properties
 
-  .. code-block:: properties
+       MODEL_COSTEER_ENV_TYPE=conda
 
-     MODEL_COSTEER_ENV_TYPE=conda
+**For the Data Science Scenario:**
+
+The execution environment is determined by the ``DS_CODER_COSTEER_ENV_TYPE`` variable, which is read from ``rdagent/components/coder/data_science/conf.py``.
+
+*   **To use Docker** (recommended for isolated execution):
+
+    .. code-block:: properties
+
+       DS_CODER_COSTEER_ENV_TYPE=docker
+
+*   **To use Conda** (for running in a local Conda environment):
+
+    .. code-block:: properties
+
+       DS_CODER_COSTEER_ENV_TYPE=conda
+
 
 
 Configuration(deprecated)


### PR DESCRIPTION
## Description

This PR adds an **Execution Environment Configuration** section to `docs/installation_and_configuration.rst`.

The new section explains:

- That RD-Agent’s model coder can run in different execution environments.
- How the execution environment is controlled by the `MODEL_COSTEER_ENV_TYPE` variable, which is read from `rdagent/components/coder/model_coder/conf.py`.
- How to switch between:
  - `MODEL_COSTEER_ENV_TYPE=docker` for isolated execution in Docker.
  - `MODEL_COSTEER_ENV_TYPE=conda` for running in a local Conda environment.

This is intended to give users a clearer, documented way to configure the execution environment, especially in quantitative scenarios.


## Motivation and Context

Many users have been confused about which environment RD-Agent actually runs code in and how to change that behavior. This is a common configuration question, especially in quantitative scenarios where users may want to control whether code runs in Docker or in a local Conda environment.

By documenting `MODEL_COSTEER_ENV_TYPE` and its options, this PR aims to:

- Reduce repeated questions about environment configuration.
- Make it easier for new users to set up RD-Agent correctly.
- Lay some groundwork for future documentation about more advanced configuration (such as custom datasets and factors).


## How Has This Been Tested?

- Not applicable – this PR only updates documentation and does not introduce any code changes.


## Screenshots of Test Results (if appropriate):

Not applicable – documentation-only change.


## Types of changes

- [ ] Fix bugs
- [ ] Add new feature
- [x] Update documentation


<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1288.org.readthedocs.build/en/1288/

<!-- readthedocs-preview RDAgent end -->