### PR TITLE
chore(ao): bootstrap Agent Orchestrator integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,4 +184,7 @@ static/
 .claude/
 AGENTS.md
 
+# Agent Orchestrator (ao)
+agent-orchestrator.yaml
+
 scripts/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,4 +47,15 @@ If you encounter any issues or have suggestions for improvements, please open an
 - Update documentation as needed.
 - Test your changes thoroughly before submitting a pull request.
 
+## Agent Orchestrator (ao)
+
+If you use Agent Orchestrator to manage parallel AI coding sessions, this repo includes a starter config template:
+
+```sh
+cp agent-orchestrator.example.yaml agent-orchestrator.yaml
+ao start
+```
+
+The local `agent-orchestrator.yaml` file is gitignored.
+
 Thank you for contributing to RD-Agent!

--- a/agent-orchestrator.example.yaml
+++ b/agent-orchestrator.example.yaml
@@ -1,0 +1,35 @@
+# Example Agent Orchestrator (ao) config for this repo.
+#
+# Usage:
+#   cp agent-orchestrator.example.yaml agent-orchestrator.yaml
+#   # then edit paths / preferences
+#   ao start
+
+dataDir: ~/.agent-orchestrator
+worktreeDir: ~/.worktrees
+
+defaults:
+  runtime: tmux
+  workspace: worktree
+
+projects:
+  rd-agent:
+    name: RD-Agent
+    sessionPrefix: rdagent
+    repo: microsoft/RD-Agent
+    defaultBranch: main
+
+    # Optional: pin to an existing local worktree.
+    # path: /abs/path/to/your/worktree/rd-agent/rd-1
+
+    agentRules: |-
+      Keep PRs focused: one issue per PR.
+      Use conventional commits (feat:, fix:, chore:, docs:, refactor:, test:).
+      Keep changes minimal; follow existing repo conventions.
+
+      Before pushing, match CI locally when possible:
+      - make lint
+      - make docs-gen
+      - make test-offline
+
+      PR titles must pass commitlint (see .commitlintrc.js).


### PR DESCRIPTION
## What
- Adds `agent-orchestrator.example.yaml` as a safe, repo-committed starter template for Agent Orchestrator (ao).
- Gitignores local `agent-orchestrator.yaml` to avoid committing machine-specific paths.
- Documents the workflow briefly in `CONTRIBUTING.md`.

## Why
- Makes it easy to onboard RD-Agent into `ao` without leaking local paths or preferences into the repo.

## Notes
- Local config remains user-specific (`agent-orchestrator.yaml`) and is intentionally ignored.

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1341.org.readthedocs.build/en/1341/

<!-- readthedocs-preview RDAgent end -->