### PR TITLE
feat: add Novita AI as LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,8 +43,18 @@ LITELLM_PROXY_API_BASE="https://api.siliconflow.cn/v1"
 EMBEDDING_MODEL="litellm_proxy/BAAI/bge-large-en-v1.5"
 # ==========================================
 
+# 3. Novita AI (OpenAI-compatible)
+# NOVITA_API_KEY="your-novita-api-key"
+# OPENAI_API_BASE="https://api.novita.ai/openai"
+# CHAT_MODEL="openai/moonshotai/kimi-k2.5"
+# # Novita also provides an embedding model:
+# LITELLM_PROXY_API_KEY="your-novita-api-key"
+# LITELLM_PROXY_API_BASE="https://api.novita.ai/openai"
+# EMBEDDING_MODEL="litellm_proxy/qwen/qwen3-embedding-0.6b"
 # ==========================================
-# Other Configuration 
+
+# ==========================================
+# Other Configuration
 # ==========================================
 # CHAT_AZURE_API_BASE=<for_Azure_user>
 # CHAT_AZURE_API_VERSION=<for_Azure_user>

--- a/docs/installation_and_configuration.rst
+++ b/docs/installation_and_configuration.rst
@@ -159,6 +159,31 @@ If your `Azure OpenAI API Key`` supports `embedding model`, you can refer to the
       AZURE_API_BASE=<your_unified_api_base>
       AZURE_API_VERSION=<azure api version>
 
+Configuration Example 3: Novita AI Setup
+-----------------------------------------
+
+`Novita AI <https://novita.ai>`_ provides an OpenAI-compatible API with a range of models.
+
+Here is a complete working example using Novita AI for both chat and embeddings:
+
+   .. code-block:: Properties
+
+      # CHAT MODEL: Novita AI via OpenAI-compatible endpoint
+      NOVITA_API_KEY=<replace_with_your_novita_api_key>
+      OPENAI_API_BASE=https://api.novita.ai/openai
+      CHAT_MODEL=openai/moonshotai/kimi-k2.5
+
+      # EMBEDDING MODEL: Novita AI embedding via litellm_proxy
+      # Note: embedding requires litellm_proxy prefix
+      LITELLM_PROXY_API_KEY=<replace_with_your_novita_api_key>
+      LITELLM_PROXY_API_BASE=https://api.novita.ai/openai
+      EMBEDDING_MODEL=litellm_proxy/qwen/qwen3-embedding-0.6b
+
+Other available Novita AI chat models:
+
+- ``openai/zai-org/glm-5``
+- ``openai/minimax/minimax-m2.5``
+
 Execution Environment Configuration
 ===================================
 

--- a/rdagent/app/utils/health_check.py
+++ b/rdagent/app/utils/health_check.py
@@ -110,6 +110,13 @@ def env_check():
             chat_api_base = os.getenv("OPENAI_API_BASE")
         else:
             chat_api_base = None
+    elif "NOVITA_API_KEY" in os.environ:
+        chat_api_key = os.getenv("NOVITA_API_KEY")
+        chat_api_base = os.getenv("OPENAI_API_BASE", "https://api.novita.ai/openai")
+        chat_model = os.getenv("CHAT_MODEL")
+        embedding_model = os.getenv("EMBEDDING_MODEL")
+        embedding_api_key = os.getenv("LITELLM_PROXY_API_KEY", chat_api_key)
+        embedding_api_base = os.getenv("LITELLM_PROXY_API_BASE", chat_api_base)
     elif "OPENAI_API_KEY" in os.environ:
         chat_api_key = os.getenv("OPENAI_API_KEY")
         chat_api_base = os.getenv("OPENAI_API_BASE")

--- a/rdagent/oai/utils/embedding.py
+++ b/rdagent/oai/utils/embedding.py
@@ -21,6 +21,7 @@ EMBEDDING_MODEL_LIMITS = {
     "bce-embedding-base_v1": 511,
     "bge-large-zh-v1.5": 511,
     "bge-large-en-v1.5": 511,
+    "qwen3-embedding-0.6b": 8192,
 }
 
 


### PR DESCRIPTION
## Summary

- Adds [Novita AI](https://novita.ai) as an OpenAI-compatible LLM provider via LiteLLM
- Registers `qwen3-embedding-0.6b` token limit (8192) in `EMBEDDING_MODEL_LIMITS`
- Adds `NOVITA_API_KEY` detection to `health_check.py` env validation
- Adds Novita AI configuration example to `.env.example`
- Adds Novita AI setup section to `docs/installation_and_configuration.rst`

## Configuration

Users can configure Novita AI by adding to their `.env`:

```properties
# Chat model
NOVITA_API_KEY=<your-novita-api-key>
OPENAI_API_BASE=https://api.novita.ai/openai
CHAT_MODEL=openai/moonshotai/kimi-k2.5

# Embedding model
LITELLM_PROXY_API_KEY=<your-novita-api-key>
LITELLM_PROXY_API_BASE=https://api.novita.ai/openai
EMBEDDING_MODEL=litellm_proxy/qwen/qwen3-embedding-0.6b
```

Novita AI uses the OpenAI-compatible endpoint, so it routes through LiteLLM's existing `openai` provider path with no new dependencies.

## Test plan

- [ ] Set `NOVITA_API_KEY` and run `rdagent health_check` — env_check should pick up the key and test chat/embedding connectivity
- [ ] Verify `openai/moonshotai/kimi-k2.5` model resolves correctly via LiteLLM with `OPENAI_API_BASE=https://api.novita.ai/openai`
- [ ] Verify `litellm_proxy/qwen/qwen3-embedding-0.6b` embedding call succeeds with Novita base URL

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1369.org.readthedocs.build/en/1369/

<!-- readthedocs-preview RDAgent end -->