### PR TITLE
fix(ui): store evolving code messages under short key for downstream consumers

### DIFF
--- a/rdagent/log/ui/app.py
+++ b/rdagent/log/ui/app.py
@@ -229,6 +229,9 @@ def get_msgs_until(end_func: Callable[[Message], bool] = lambda _: True):
                         state.hypotheses[state.lround] = msg.content
                     elif "evolving code" in tags:
                         msg.content = [i for i in msg.content if i]
+                        # Also store under the short key so downstream consumers
+                        # that read state.msgs[round]["evolving code"] can find it.
+                        state.msgs[state.lround]["evolving code"].append(msg)
                     elif "evolving feedback" in tags:
                         total_len = len(msg.content)
                         none_num = total_len - len(msg.content)


### PR DESCRIPTION
Fixes #1021

The `get_msgs_until` function stores messages under `state.msgs[lround][msg.tag]`, where `msg.tag` is the full tag string (e.g. `"development.evoving code"`). However, downstream consumers read from `state.msgs[round]["evolving code"]` (lines 474, 476, 700), which never gets populated.

This fix explicitly appends evolving code messages under the short `"evolving code"` key so the UI can display them correctly.

**Changes:**
- In the `"evolving code" in tags` branch of `get_msgs_until`, also append to `state.msgs[lround]["evolving code"]`

**Testing:**
- Manually verified the fix produces the expected behavior described in the issue

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1373.org.readthedocs.build/en/1373/

<!-- readthedocs-preview RDAgent end -->