### PR TITLE
fix: add authentication to Flask server mutating endpoints (CWE-306)

### DIFF
--- a/rdagent/log/server/app.py
+++ b/rdagent/log/server/app.py
@@ -1,10 +1,12 @@
 import logging
 import os
 import random
+import secrets
 import traceback
 from collections import defaultdict
 from contextlib import redirect_stderr, redirect_stdout
 from datetime import datetime, timezone
+from functools import wraps
 from multiprocessing import Process, Queue
 from pathlib import Path
 from queue import Empty
@@ -22,6 +24,19 @@ from rdagent.log.ui.storage import WebStorage
 app = Flask(__name__, static_folder=str(Path(UI_SETTING.static_path).resolve()))
 CORS(app)
 app.config["UI_SERVER_PORT"] = 19899
+
+# --- Authentication -----------------------------------------------------------
+# The API token is read from the UI_API_TOKEN environment variable.
+# When set, all mutating endpoints require an ``Authorization: Bearer <token>``
+# header.  When *not* set, a random token is generated at startup and printed to
+# the console so the operator can still authenticate.
+_configured_token = os.environ.get("UI_API_TOKEN", "").strip()
+if _configured_token:
+    app.config["API_TOKEN"] = _configured_token
+else:
+    _auto_token = secrets.token_urlsafe(32)
+    app.config["API_TOKEN"] = _auto_token
+    # Will be printed once ``main()`` starts the server.
 
 _YELLOW = "\033[33m"
 _RESET = "\033[0m"
@@ -44,6 +59,49 @@ def _configure_app_logger() -> None:
 
 
 _configure_app_logger()
+
+
+# ---------------------------------------------------------------------------
+# Authentication helpers
+# ---------------------------------------------------------------------------
+
+def _check_api_token() -> bool:
+    """Return True if the request carries a valid Bearer token."""
+    token = app.config.get("API_TOKEN", "")
+    if not token:
+        return True  # no token configured → open (legacy behaviour)
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        return secrets.compare_digest(auth_header[7:], token)
+    return False
+
+
+def require_auth(f):
+    """Decorator that rejects requests without a valid API token."""
+
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if not _check_api_token():
+            return jsonify({"error": "Unauthorized – provide a valid Bearer token via the Authorization header."}), 401
+        return f(*args, **kwargs)
+
+    return decorated
+
+
+# ---------------------------------------------------------------------------
+# Allowed scenarios (whitelist)
+# ---------------------------------------------------------------------------
+
+_VALID_SCENARIOS = frozenset(
+    {
+        "Finance Data Building",
+        "Finance Model Implementation",
+        "Finance Whole Pipeline",
+        "Finance Data Building (Reports)",
+        "General Model Implementation",
+        "Data Science",
+    }
+)
 
 
 _TARGETS_WITHOUT_USER_INTERACTION = {"general_model", "fin_factor_report"}
@@ -383,6 +441,7 @@ def list_traces():
 
 
 @app.route("/upload", methods=["POST"])
+@require_auth
 def upload_file():
     # 获取请求体中的字段
     global rdagent_processes
@@ -391,6 +450,10 @@ def upload_file():
     competition = request.form.get("competition")
     loop_n = request.form.get("loops")
     all_duration = request.form.get("all_duration")
+
+    # Validate scenario against the allowlist before any processing.
+    if scenario not in _VALID_SCENARIOS:
+        return jsonify({"error": "Unknown scenario"}), 400
 
     # scenario = "Data Science Loop"
     if scenario == "Data Science":
@@ -486,6 +549,7 @@ def upload_file():
 
 
 @app.route("/receive", methods=["POST"])
+@require_auth
 def receive_msgs():
     try:
         data = request.get_json()
@@ -506,6 +570,7 @@ def receive_msgs():
 
 
 @app.route("/user_interaction/submit", methods=["POST"])
+@require_auth
 def submit_user_interaction_response():
     """Frontend submits a user response; server forwards it to the rdagent subprocess via IPC queue."""
     data = request.get_json(silent=True) or {}
@@ -529,6 +594,7 @@ def submit_user_interaction_response():
 
 
 @app.route("/control", methods=["POST"])
+@require_auth
 def control_process():
     global rdagent_processes
     data = request.get_json()
@@ -588,10 +654,19 @@ def server_static_files(fn):
     return send_from_directory(app.static_folder, _normalize_static_request_path(fn))
 
 
-def main(port: int = 19899):
+def main(port: int = 19899, host: str = "127.0.0.1"):
     app.config["UI_SERVER_PORT"] = port
+
+    if not _configured_token:
+        app.logger.warning(
+            "No UI_API_TOKEN set — a random token has been generated for this session.\n"
+            "  Authorization: Bearer %s\n"
+            "Set the UI_API_TOKEN environment variable to use a persistent token.",
+            app.config["API_TOKEN"],
+        )
+
     _load_existing_traces(log_folder_path)
-    app.run(debug=False, host="0.0.0.0", port=port)
+    app.run(debug=False, host=host, port=port)
 
 
 if __name__ == "__main__":

--- a/tests/test_cwe94_unauthenticated_upload.py
+++ b/tests/test_cwe94_unauthenticated_upload.py
@@ -1,0 +1,179 @@
+"""
+PoC test for CWE-94: Unauthenticated arbitrary process execution via /upload endpoint.
+
+The Flask server in rdagent/log/server/app.py listens on 0.0.0.0 with no
+authentication. Any network-reachable client can POST to /upload with a
+crafted scenario and attacker-controlled parameters, causing the server to
+spawn a new Process that executes rdagent internal targets with those parameters.
+
+This test:
+1. Validates that /upload currently accepts requests with NO authentication
+   and successfully creates an RDAgentTask (returns 200).
+2. Validates that /receive, /control, /user_interaction/submit also lack auth.
+3. After the fix, these endpoints should require an API token and return 401/403
+   when called without one.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+# The rdagent package is properly importable from this repo.
+# We only need to mock the subprocess spawning.
+
+
+class TestUnauthenticatedAccess(unittest.TestCase):
+    """Test that mutating endpoints require authentication."""
+
+    @classmethod
+    def setUpClass(cls):
+        os.makedirs("/tmp/rdagent_test_static", exist_ok=True)
+        os.makedirs("/tmp/rdagent_test_traces", exist_ok=True)
+
+        from rdagent.log.server.app import app as flask_app, rdagent_processes
+
+        cls.flask_app = flask_app
+        cls.rdagent_processes = rdagent_processes
+        flask_app.config["TESTING"] = True
+
+    def setUp(self):
+        self.client = self.flask_app.test_client()
+        self.rdagent_processes.clear()
+
+    def test_upload_no_auth_spawns_process(self):
+        """
+        /upload should reject unauthenticated requests.
+
+        BEFORE FIX: returns 200, creates a task, spawns a process
+        AFTER FIX: returns 401 (Unauthorized)
+        """
+        with patch("rdagent.log.server.app.Process") as MockProcess:
+            mock_proc = MagicMock()
+            mock_proc.is_alive.return_value = True
+            MockProcess.return_value = mock_proc
+
+            response = self.client.post(
+                "/upload",
+                data={
+                    "scenario": "Finance Data Building",
+                    "loops": "1",
+                    "all_duration": "1",
+                },
+                content_type="multipart/form-data",
+            )
+
+            # AFTER FIX: This should return 401, not 200
+            self.assertEqual(
+                response.status_code,
+                401,
+                f"Expected 401 Unauthorized for unauthenticated /upload, "
+                f"got {response.status_code}. Response: {response.get_data(as_text=True)}",
+            )
+
+    def test_receive_no_auth_injects_messages(self):
+        """
+        /receive should reject unauthenticated requests.
+
+        BEFORE FIX: returns 200, injects message into trace
+        AFTER FIX: returns 401 (Unauthorized)
+        """
+        response = self.client.post(
+            "/receive",
+            json={"id": "test/trace", "msg": {"tag": "injected", "content": "malicious"}},
+        )
+        self.assertEqual(
+            response.status_code,
+            401,
+            f"Expected 401 Unauthorized for unauthenticated /receive, "
+            f"got {response.status_code}",
+        )
+
+    def test_control_no_auth_stops_process(self):
+        """
+        /control should reject unauthenticated requests.
+
+        BEFORE FIX: returns 200/400, can stop any running process
+        AFTER FIX: returns 401 (Unauthorized)
+        """
+        response = self.client.post(
+            "/control",
+            json={"id": "test/trace", "action": "stop"},
+        )
+        self.assertEqual(
+            response.status_code,
+            401,
+            f"Expected 401 Unauthorized for unauthenticated /control, "
+            f"got {response.status_code}",
+        )
+
+    def test_user_interaction_no_auth(self):
+        """
+        /user_interaction/submit should reject unauthenticated requests.
+
+        BEFORE FIX: returns 200, enqueues payload
+        AFTER FIX: returns 401 (Unauthorized)
+        """
+        response = self.client.post(
+            "/user_interaction/submit",
+            json={"id": "test/trace", "payload": {"answer": "yes"}},
+        )
+        self.assertEqual(
+            response.status_code,
+            401,
+            f"Expected 401 Unauthorized for unauthenticated /user_interaction/submit, "
+            f"got {response.status_code}",
+        )
+
+    def test_upload_with_valid_token(self):
+        """
+        /upload should accept requests with a valid API token.
+        """
+        with patch("rdagent.log.server.app.Process") as MockProcess:
+            mock_proc = MagicMock()
+            mock_proc.is_alive.return_value = True
+            MockProcess.return_value = mock_proc
+
+            token = self.flask_app.config.get("API_TOKEN", "")
+            if not token:
+                self.skipTest("No API_TOKEN configured")
+
+            response = self.client.post(
+                "/upload",
+                data={
+                    "scenario": "Finance Data Building",
+                    "loops": "1",
+                    "all_duration": "1",
+                },
+                headers={"Authorization": f"Bearer {token}"},
+                content_type="multipart/form-data",
+            )
+
+            self.assertEqual(
+                response.status_code,
+                200,
+                f"Expected 200 for authenticated /upload, got {response.status_code}",
+            )
+
+    def test_read_only_endpoints_accessible(self):
+        """
+        Read-only endpoints (/, /traces, /test) should remain accessible
+        without auth since they don't mutate state or spawn processes.
+        """
+        response = self.client.get("/traces")
+        self.assertIn(
+            response.status_code,
+            [200],
+            f"Expected /traces to remain accessible, got {response.status_code}",
+        )
+
+        response = self.client.get("/test")
+        self.assertIn(
+            response.status_code,
+            [200],
+            f"Expected /test to remain accessible, got {response.status_code}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Vulnerability Summary

**CWE:** CWE-306 (Missing Authentication for Critical Function)
**Severity:** High
**Affected file:** `rdagent/log/server/app.py`

### Data Flow

1. Flask server binds on `0.0.0.0:19899` (all network interfaces) with wildcard CORS (`CORS(app)` — no origin restriction).
2. Four mutating endpoints — `/upload`, `/receive`, `/control`, `/user_interaction/submit` — have **zero authentication**: no `login_required`, no API token, no bearer check.
3. Any network-reachable client can:
   - **`POST /upload`** — spawn `multiprocessing.Process` instances that run rdagent pipelines, consuming LLM API keys (financial impact).
   - **`POST /receive`** — inject arbitrary messages into traces (integrity compromise).
   - **`POST /control`** — stop any running agent process (denial of service).
   - **`POST /user_interaction/submit`** — inject user-interaction responses, manipulating agent decision-making.

### Preconditions

Network access to port 19899. Since the server binds `0.0.0.0`, any peer on the same LAN, VPC, or Wi-Fi network can reach it. This does **not** require shell access to the host — network access alone only grants read-only UI viewing; the unauthenticated endpoints are what grant write/control capabilities.

---

## Fix Description & Rationale

This PR applies four defence-in-depth measures:

| Change | Rationale |
|--------|-----------|
| **`@require_auth` decorator** on all 4 mutating endpoints | Core fix — requests must carry a valid `Authorization: Bearer <token>` header. Uses `secrets.compare_digest` to prevent timing attacks. |
| **Auto-generated token** when `UI_API_TOKEN` env var is unset | Prevents "open by default" — a random 32-byte token is generated at startup and printed to the console. |
| **Bind address changed** from `0.0.0.0` to `127.0.0.1` | Reduces attack surface — server is only reachable from localhost by default. Accepts `host` parameter for explicit override. |
| **Scenario whitelist** (`_VALID_SCENARIOS` frozenset) | Validates the `scenario` parameter against known values **before** any filesystem operations or process spawning. |

### Files Changed (4 files, minimal diff)

- `rdagent/log/server/app.py` — auth decorator, token config, bind address, scenario whitelist, trace history loading
- `tests/test_cwe94_unauthenticated_upload.py` — regression tests validating auth enforcement
- `web/src/utils/api.js` — new `getHistoryTraceIds()` helper for `/traces` endpoint
- `web/src/views/Playground.vue` — load history traces from backend (supports the new `/traces` read-only endpoint)

---

## Test Results Summary

The test file `tests/test_cwe94_unauthenticated_upload.py` covers:

| Test | What it validates |
|------|-------------------|
| `test_upload_no_auth_spawns_process` | `/upload` returns 401 without token |
| `test_receive_no_auth_injects_messages` | `/receive` returns 401 without token |
| `test_control_no_auth_stops_process` | `/control` returns 401 without token |
| `test_user_interaction_no_auth` | `/user_interaction/submit` returns 401 without token |
| `test_upload_with_valid_token` | `/upload` returns 200 with valid Bearer token |
| `test_read_only_endpoints_accessible` | `/traces` and `/test` remain accessible without auth |

---

## Disprove Analysis Results

We conducted a systematic attempt to invalidate this finding:

### Authentication Check
The original `app.py` (commit `471eb30`) has **zero authentication** on any endpoint. No `login_required`, `@auth`, `Bearer`, `api_key`, or token checks exist.

### Network Exposure Check
- Server binds `0.0.0.0:19899` — all interfaces
- `CORS(app)` with no arguments = wildcard CORS (all origins allowed)
- No ALLOWED_HOSTS, IP restrictions, or firewall rules

### Deployment Check
No Dockerfile specifically for the web server. README says `rdagent server_ui --port 19899`. No evidence of reverse proxy, VPN, or service mesh requirements. The server is intended for direct usage.

### Precondition Equivalence Analysis

| Precondition | Access it already grants | Vulnerability provides |
|---|---|---|
| Network access to port 19899 | Can view web UI (read-only) | Can spawn processes, stop processes, inject messages, control agent behavior |

**Conclusion:** Network access alone is read-only. The vulnerability grants full write/control access. **Not redundant.**

### Exploit Sketch

```bash
# Spawn expensive LLM-calling processes (financial impact)
curl -X POST http://<target>:19899/upload \
  -F "scenario=Data Science" -F "competition=MLE-Bench:titanic" -F "loops=100"

# Inject fake messages into traces (integrity)
curl -X POST http://<target>:19899/receive \
  -H "Content-Type: application/json" \
  -d '{"id":"/path/to/trace","msg":{"tag":"END","content":{"error_msg":"Fake"}}}'

# Stop running processes (DoS)
curl -X POST http://<target>:19899/control \
  -H "Content-Type: application/json" -d '{"id":"some-trace","action":"stop"}'
```

### Fix Adequacy
The fix addresses the core issue comprehensively. No parallel path bypasses the auth decorator. The auto-generated token prevents "open by default." The bind address change reduces network exposure.

### Mitigations Already Present (Insufficient)
- `secure_filename` + `commonpath` on uploads (file-path safety only)
- Unknown scenarios fail before process spawn — but **after** directory creation and file writing
- Application code is fixed (not arbitrary user code) — but process spawning and message injection are still high-impact

### Similar Vulnerabilities Found
- `rdagent/log/server/debug_app.py` has identical unauthenticated endpoints (separate debug file, not addressed here)
- `rdagent/scenarios/rl/autorl_bench/core/server.py` also binds `0.0.0.0`

### Verdict: **CONFIRMED_VALID** (High Confidence)

---

## Notes

- The initial CWE classification was CWE-94 (Code Injection). The more accurate classification is **CWE-306** (Missing Authentication for Critical Function) — the endpoints execute fixed application code, but without authentication, an attacker controls *which* code paths execute and with *what parameters*.
- Two prior unmerged branches attempted to fix the same issue (`fix/cwe306-app-unauthenti-6787`, `fix/cwe306-app-unauthenti-b618`). This branch is the most complete, adding auto-token generation, bind address hardening, and scenario whitelisting.
- Consider also restricting CORS origins and applying auth to `debug_app.py` as follow-ups.

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1388.org.readthedocs.build/en/1388/

<!-- readthedocs-preview RDAgent end -->