### PR TITLE
feat(litellm): add support for embedding extra parameters and OpenAI-Compatible Endpoints

### DIFF
--- a/rdagent/app/utils/health_check.py
+++ b/rdagent/app/utils/health_check.py
@@ -99,6 +99,13 @@ def env_check():
         embedding_model = os.getenv("EMBEDDING_MODEL")
         embedding_api_key = chat_api_key
         embedding_api_base = chat_api_base
+    elif "CHAT_OPENAI_COMPATIBLE_API_KEY" in os.environ or "EMBEDDING_OPENAI_COMPATIBLE_API_KEY" in os.environ:
+        chat_api_key = os.getenv("CHAT_OPENAI_COMPATIBLE_API_KEY")
+        chat_api_base = os.getenv("CHAT_OPENAI_COMPATIBLE_API_BASE")
+        chat_model = os.getenv("CHAT_MODEL")
+        embedding_model = os.getenv("EMBEDDING_MODEL")
+        embedding_api_key = os.getenv("EMBEDDING_OPENAI_COMPATIBLE_API_KEY")
+        embedding_api_base = os.getenv("EMBEDDING_OPENAI_COMPATIBLE_API_BASE")
     else:
         logger.error("No valid configuration was found, please check your .env file.")
 

--- a/rdagent/app/utils/health_check.py
+++ b/rdagent/app/utils/health_check.py
@@ -3,9 +3,6 @@ import socket
 
 import docker
 import fire
-import litellm
-from litellm import completion, embedding
-from litellm.utils import ModelResponse
 
 from rdagent.log import rdagent_logger as logger
 from rdagent.utils.env import cleanup_container
@@ -51,24 +48,11 @@ def check_and_list_free_ports(start_port=19899, max_ports=10) -> None:
 def test_chat(chat_model, chat_api_key, chat_api_base):
     logger.info(f"🧪 Testing chat model: {chat_model}")
     try:
-        if chat_api_base is None:
-            response: ModelResponse = completion(
-                model=chat_model,
-                api_key=chat_api_key,
-                messages=[
-                    {"role": "user", "content": "Hello!"},
-                ],
-            )
-        else:
-            response: ModelResponse = completion(
-                model=chat_model,
-                api_key=chat_api_key,
-                api_base=chat_api_base,
-                messages=[
-                    {"role": "user", "content": "Hello!"},
-                ],
-            )
-        logger.info(f"✅ Chat test passed.")
+        from rdagent.oai.backend.litellm import LiteLLMAPIBackend
+
+        backend = LiteLLMAPIBackend()
+        backend.build_messages_and_create_chat_completion(user_prompt="Hello!")
+        logger.info("✅ Chat test passed.")
         return True
     except Exception as e:
         logger.error(f"❌ Chat test failed: {e}")
@@ -78,12 +62,10 @@ def test_chat(chat_model, chat_api_key, chat_api_base):
 def test_embedding(embedding_model, embedding_api_key, embedding_api_base):
     logger.info(f"🧪 Testing embedding model: {embedding_model}")
     try:
-        response = embedding(
-            model=embedding_model,
-            api_key=embedding_api_key,
-            api_base=embedding_api_base,
-            input="Hello world!",
-        )
+        from rdagent.oai.backend.litellm import LiteLLMAPIBackend
+
+        backend = LiteLLMAPIBackend()
+        backend.create_embedding(input_content="Hello world!")
         logger.info("✅ Embedding test passed.")
         return True
     except Exception as e:

--- a/rdagent/oai/backend/litellm.py
+++ b/rdagent/oai/backend/litellm.py
@@ -82,8 +82,15 @@ class LiteLLMAPIBackend(APIBackend):
         call_kwargs = {
             "model": model_name,
             "input": input_content_list,
-            **LITELLM_SETTINGS.embedding_extra_params,
         }
+        if LITELLM_SETTINGS.embedding_extra_params:
+            if isinstance(LITELLM_SETTINGS.embedding_extra_params, dict):
+                call_kwargs.update(LITELLM_SETTINGS.embedding_extra_params)
+            else:
+                logger.error(
+                    f"{LogColors.RED}embedding_extra_params must be a dict, got {type(LITELLM_SETTINGS.embedding_extra_params).__name__}. Ignoring extra params.{LogColors.END}",
+                    tag="debug_litellm_emb",
+                )
         # Use embedding OpenAI-Compatible config
         if LITELLM_SETTINGS.embedding_openai_compatible_api_key:
             call_kwargs["api_key"] = LITELLM_SETTINGS.embedding_openai_compatible_api_key
@@ -160,18 +167,16 @@ class LiteLLMAPIBackend(APIBackend):
         model = complete_kwargs["model"]
 
         # Use OpenAI-Compatible API config for chat completion
-        call_kwargs: dict[str, Any] = {}
         if LITELLM_SETTINGS.chat_openai_compatible_api_key:
-            call_kwargs["api_key"] = LITELLM_SETTINGS.chat_openai_compatible_api_key
+            complete_kwargs["api_key"] = LITELLM_SETTINGS.chat_openai_compatible_api_key
         if LITELLM_SETTINGS.chat_openai_compatible_api_base:
-            call_kwargs["api_base"] = LITELLM_SETTINGS.chat_openai_compatible_api_base
+            complete_kwargs["api_base"] = LITELLM_SETTINGS.chat_openai_compatible_api_base
 
         response = completion(
             messages=messages,
             stream=LITELLM_SETTINGS.chat_stream,
             max_retries=0,
             **complete_kwargs,
-            **call_kwargs,
             **kwargs,
         )
         if LITELLM_SETTINGS.log_llm_chat_content:

--- a/rdagent/oai/backend/litellm.py
+++ b/rdagent/oai/backend/litellm.py
@@ -79,10 +79,16 @@ class LiteLLMAPIBackend(APIBackend):
                 f"{LogColors.MAGENTA}Creating embedding{LogColors.END} for: {input_content_list}",
                 tag="debug_litellm_emb",
             )
-        response = embedding(
-            model=model_name,
-            input=input_content_list,
-        )
+        call_kwargs = {
+            "model": model_name,
+            "input": input_content_list,
+            **LITELLM_SETTINGS.embedding_extra_params,
+        }
+        if LITELLM_SETTINGS.embedding_openai_api_key:
+            call_kwargs["api_key"] = LITELLM_SETTINGS.embedding_openai_api_key
+        if LITELLM_SETTINGS.embedding_openai_base_url:
+            call_kwargs["api_base"] = LITELLM_SETTINGS.embedding_openai_base_url
+        response = embedding(**call_kwargs)
         response_list = [data["embedding"] for data in response.data]
         return response_list
 

--- a/rdagent/oai/backend/litellm.py
+++ b/rdagent/oai/backend/litellm.py
@@ -84,11 +84,11 @@ class LiteLLMAPIBackend(APIBackend):
             "input": input_content_list,
             **LITELLM_SETTINGS.embedding_extra_params,
         }
-        # Use proxy config from LITELLM_SETTINGS (reads LITELLM_PROXY_API_KEY and LITELLM_PROXY_API_BASE)
-        if LITELLM_SETTINGS.proxy_api_key:
-            call_kwargs["api_key"] = LITELLM_SETTINGS.proxy_api_key
-        if LITELLM_SETTINGS.proxy_api_base:
-            call_kwargs["api_base"] = LITELLM_SETTINGS.proxy_api_base
+        # Use embedding OpenAI-Compatible config
+        if LITELLM_SETTINGS.embedding_openai_compatible_api_key:
+            call_kwargs["api_key"] = LITELLM_SETTINGS.embedding_openai_compatible_api_key
+        if LITELLM_SETTINGS.embedding_openai_compatible_api_base:
+            call_kwargs["api_base"] = LITELLM_SETTINGS.embedding_openai_compatible_api_base
         response = embedding(**call_kwargs)
         response_list = [data["embedding"] for data in response.data]
         return response_list
@@ -159,11 +159,19 @@ class LiteLLMAPIBackend(APIBackend):
         complete_kwargs = self.get_complete_kwargs()
         model = complete_kwargs["model"]
 
+        # Use OpenAI-Compatible API config for chat completion
+        call_kwargs: dict[str, Any] = {}
+        if LITELLM_SETTINGS.chat_openai_compatible_api_key:
+            call_kwargs["api_key"] = LITELLM_SETTINGS.chat_openai_compatible_api_key
+        if LITELLM_SETTINGS.chat_openai_compatible_api_base:
+            call_kwargs["api_base"] = LITELLM_SETTINGS.chat_openai_compatible_api_base
+
         response = completion(
             messages=messages,
             stream=LITELLM_SETTINGS.chat_stream,
             max_retries=0,
             **complete_kwargs,
+            **call_kwargs,
             **kwargs,
         )
         if LITELLM_SETTINGS.log_llm_chat_content:

--- a/rdagent/oai/backend/litellm.py
+++ b/rdagent/oai/backend/litellm.py
@@ -84,10 +84,11 @@ class LiteLLMAPIBackend(APIBackend):
             "input": input_content_list,
             **LITELLM_SETTINGS.embedding_extra_params,
         }
-        if LITELLM_SETTINGS.embedding_openai_api_key:
-            call_kwargs["api_key"] = LITELLM_SETTINGS.embedding_openai_api_key
-        if LITELLM_SETTINGS.embedding_openai_base_url:
-            call_kwargs["api_base"] = LITELLM_SETTINGS.embedding_openai_base_url
+        # Use proxy config from LITELLM_SETTINGS (reads LITELLM_PROXY_API_KEY and LITELLM_PROXY_API_BASE)
+        if LITELLM_SETTINGS.proxy_api_key:
+            call_kwargs["api_key"] = LITELLM_SETTINGS.proxy_api_key
+        if LITELLM_SETTINGS.proxy_api_base:
+            call_kwargs["api_base"] = LITELLM_SETTINGS.proxy_api_base
         response = embedding(**call_kwargs)
         response_list = [data["embedding"] for data in response.data]
         return response_list

--- a/rdagent/oai/llm_conf.py
+++ b/rdagent/oai/llm_conf.py
@@ -87,6 +87,7 @@ class LLMSettings(ExtendedBaseSettings):
     embedding_azure_api_version: str = ""
     embedding_max_str_num: int = 50
     embedding_max_length: int = 8192
+    embedding_extra_params: dict = {}
 
     # offline llama2 related config
     use_llama2: bool = False

--- a/rdagent/oai/llm_conf.py
+++ b/rdagent/oai/llm_conf.py
@@ -66,6 +66,9 @@ class LLMSettings(ExtendedBaseSettings):
     chat_openai_base_url: str | None = None  #
     chat_azure_api_base: str = ""
     chat_azure_api_version: str = ""
+    # OpenAI-Compatible API config (for chat completion)
+    chat_openai_compatible_api_key: str = ""
+    chat_openai_compatible_api_base: str = ""
     chat_max_tokens: int | None = None
     chat_temperature: float = 0.5
     chat_stream: bool = True
@@ -88,9 +91,9 @@ class LLMSettings(ExtendedBaseSettings):
     embedding_max_str_num: int = 50
     embedding_max_length: int = 8192
     embedding_extra_params: dict = {}
-    # LiteLLM proxy config (for embedding)
-    proxy_api_key: str = ""
-    proxy_api_base: str = ""
+    # OpenAI-Compatible API config (for embedding)
+    embedding_openai_compatible_api_key: str = ""
+    embedding_openai_compatible_api_base: str = ""
 
     # offline llama2 related config
     use_llama2: bool = False

--- a/rdagent/oai/llm_conf.py
+++ b/rdagent/oai/llm_conf.py
@@ -88,6 +88,9 @@ class LLMSettings(ExtendedBaseSettings):
     embedding_max_str_num: int = 50
     embedding_max_length: int = 8192
     embedding_extra_params: dict = {}
+    # LiteLLM proxy config (for embedding)
+    proxy_api_key: str = ""
+    proxy_api_base: str = ""
 
     # offline llama2 related config
     use_llama2: bool = False


### PR DESCRIPTION
<!--- Thank you for submitting a Pull Request! In order to make our work smoother. -->
<!--- please make sure your Pull Request meets the following requirements: -->
<!---   1. Provide a general summary of your changes in the Title above; -->
<!---   2. Add appropriate prefixes to titles, such as `build:`, `chore:`, `ci:`, `docs:`, `feat:`, `fix:`, `perf:`, `refactor:`, `revert:`, `style:`, `test:`(Ref: https://www.conventionalcommits.org/). -->
<!--- Category: -->
<!--- Patch Updates: `fix:` -->
<!---   Example: fix(auth): correct login validation issue -->
<!--- minor update (introduces new functionality): `feat` -->
<!---   Example: feature(parser): add ability to parse arrays -->
<!--- major update(destructive update): Include BREAKING CHANGE in the commit message footer, or add `! ` in the commit footer to indicate that there is a destructive update. -->
<!---   Example: feat(auth)! : remove support for old authentication method -->
<!--- Other updates: `build:`, `chore:`, `ci:`, `docs:`, `perf:`, `refactor:`, `revert:`, `style:`, `test:`. -->

## Description
Fix the embedding test failure in rdagent health_check and add support for embedding extra parameters configuration.

  Key changes:
  1. health_check: Refactor test_embedding and test_chat to use LiteLLMAPIBackend production code path, avoiding the issue where health_check
  passes but actual calls fail
  2. llm_conf: Add embedding_extra_params config option, supports setting provider-specific parameters via LITELLM_EMBEDDING_EXTRA_PARAMS env
  var (e.g., SiliconFlow requires encoding_format: float)
  3. litellm: _create_embedding_inner_function now passes embedding_openai_api_key, embedding_openai_base_url, and embedding_extra_params
  parameters

## Motivation and Context
  When running rdagent health_check, the embedding test failed with error:
  litellm.BadRequestError: Litellm_proxyException - Error code: 400 - {'code': 20015, 'message': 'The parameter is invalid. Please check
  again.', 'data': None}

  Root causes:
  - SiliconFlow's /embeddings API requires encoding_format="float" parameter
  - Original health_check directly called litellm.embedding() without using production code path
  - Production code didn't support passing extra parameters and separate embedding API config
  
After fix, users can configure in .env:
    CHAT_MODEL=openai/kimi-k2.6
    CHAT_OPENAI_COMPATIBLE_API_KEY=ark-xxxx
    CHAT_OPENAI_COMPATIBLE_API_BASE=https://ark.cn-beijing.volces.com/api/coding/v3

    EMBEDDING_MODEL=openai/BAAI/bge-m3
    EMBEDDING_OPENAI_COMPATIBLE_API_KEY=sk-xxxx
    EMBEDDING_OPENAI_COMPATIBLE_API_BASE=https://api.siliconflow.cn/v1
    EMBEDDING_EXTRA_PARAMS='{"encoding_format": "float"}'

## How Has This Been Tested?
  - Run rdagent health_check to verify all tests pass (embedding, chat, docker, port)
  - Run unittest
  
<img width="1793" height="620" alt="image" src="https://github.com/user-attachments/assets/6c8936fd-18d1-48a1-86e4-6c9072a32aa9" />

## Screenshots of Test Results (if appropriate):
1. Your own tests:


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [x] Add new feature
- [ ] Update documentation


<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1395.org.readthedocs.build/en/1395/

<!-- readthedocs-preview RDAgent end -->