### PR TITLE
fix: harden AutoRL-Bench RL evaluators

### DIFF
--- a/rdagent/components/benchmark/configs/opencompass_template.yaml
+++ b/rdagent/components/benchmark/configs/opencompass_template.yaml
@@ -58,6 +58,7 @@ template: |-
                 trust_remote_code=True,
                 dtype='{{ dtype }}',
                 max_model_len={{ max_seq_len }},
+                enforce_eager=True,
             ),
             max_seq_len={{ max_seq_len }},
             max_out_len={{ max_out_len }},

--- a/rdagent/scenarios/rl/autorl_bench/benchmarks/alfworld/eval.py
+++ b/rdagent/scenarios/rl/autorl_bench/benchmarks/alfworld/eval.py
@@ -12,7 +12,6 @@ ReAct 官方代码: https://github.com/ysymyth/ReAct/blob/main/alfworld.ipynb
 import json
 import os
 import sys
-import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List
@@ -45,10 +44,24 @@ class _Tee:
     def fileno(self):
         return self.terminal.fileno()
 
+    def close(self):
+        self.log.close()
+
 
 def _log(msg: str):
     """简单的 print 日志（会被 Tee 同时写入文件）"""
     print(msg, flush=True)
+
+
+def _truncate_prompt_to_fit(prompt: str, tokenizer, max_context_tokens: int, max_output_tokens: int) -> str:
+    """Trim old ReAct history when it no longer fits the vLLM context."""
+
+    prompt_token_ids = tokenizer.encode(prompt)
+    if len(prompt_token_ids) + max_output_tokens <= max_context_tokens:
+        return prompt
+
+    keep_tokens = max(max_context_tokens - max_output_tokens - 1, 1)
+    return tokenizer.decode(prompt_token_ids[-keep_tokens:])
 
 
 # ============================================================
@@ -125,11 +138,19 @@ def create_llm_fn(backend: str, model_path: str, **kwargs) -> tuple:
         from vllm.distributed.parallel_state import destroy_model_parallel
 
         llm_engine = LLM(
-            model=model_path, tensor_parallel_size=kwargs.get("tensor_parallel_size", 1), trust_remote_code=True
+            model=model_path,
+            tensor_parallel_size=kwargs.get("tensor_parallel_size", 1),
+            trust_remote_code=True,
+            max_model_len=kwargs.get("max_model_len", 4096),
+            enforce_eager=kwargs.get("enforce_eager", os.getenv("VLLM_ENFORCE_EAGER", "0") == "1"),
         )
+        tokenizer = llm_engine.get_tokenizer()
+        max_context_tokens = kwargs.get("max_model_len", 4096)
 
         def vllm_fn(prompt: str, stop: List[str] = None) -> str:
-            params = SamplingParams(temperature=0, max_tokens=100, stop=stop or ["\n"])
+            max_output_tokens = 100
+            prompt = _truncate_prompt_to_fit(prompt, tokenizer, max_context_tokens, max_output_tokens)
+            params = SamplingParams(temperature=0, max_tokens=max_output_tokens, stop=stop or ["\n"])
             outputs = llm_engine.generate([prompt], params)
             return outputs[0].outputs[0].text
 
@@ -230,125 +251,140 @@ class ALFWorldEvaluator(BaseEvaluator):
         LOG_DIR.mkdir(parents=True, exist_ok=True)
         model_safe = model_path.replace("/", "_")
         log_file = LOG_DIR / f"alfworld_{model_safe}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
-        sys.stdout = _Tee(log_file)
+        old_stdout = sys.stdout
+        tee = _Tee(log_file)
+        sys.stdout = tee
+        env = None
+        llm_cleanup = None
 
-        # --- 判断 backend ---
-        backend = cfg.get("backend")
-        if backend is None:
-            backend = "api" if not Path(model_path).exists() else "vllm"
-        _log(f"Log: {log_file}")
-        _log(f"ALFWorld eval: backend={backend}, model={model_path}")
+        try:
+            # --- 判断 backend ---
+            backend = cfg.get("backend")
+            if backend is None:
+                backend = "api" if not Path(model_path).exists() else "vllm"
+            _log(f"Log: {log_file}")
+            _log(f"ALFWorld eval: backend={backend}, model={model_path}")
 
-        # --- 创建 LLM 函数 ---
-        llm_fn, llm_cleanup = create_llm_fn(
-            backend=backend,
-            model_path=model_path,
-            api_key=cfg.get("api_key"),
-            api_base=cfg.get("api_base"),
-            tensor_parallel_size=cfg.get("tensor_parallel_size", 1),
-        )
+            # --- 创建 LLM 函数 ---
+            llm_fn, llm_cleanup = create_llm_fn(
+                backend=backend,
+                model_path=model_path,
+                api_key=cfg.get("api_key"),
+                api_base=cfg.get("api_base"),
+                tensor_parallel_size=cfg.get("tensor_parallel_size", 1),
+                max_model_len=cfg.get("max_model_len", 4096),
+                enforce_eager=cfg.get("enforce_eager", os.getenv("VLLM_ENFORCE_EAGER", "0") == "1"),
+            )
 
-        # --- 加载 ReAct few-shot prompts ---
-        prompts_path = cfg.get("react_prompts")
-        if prompts_path is None:
-            # 默认路径：和 eval.py 同目录下的 react_prompts.json
-            prompts_path = Path(__file__).parent / "react_prompts.json"
-        with open(prompts_path) as f:
-            react_prompts = json.load(f)
+            # --- 加载 ReAct few-shot prompts ---
+            prompts_path = cfg.get("react_prompts")
+            if prompts_path is None:
+                # 默认路径：和 eval.py 同目录下的 react_prompts.json
+                prompts_path = Path(__file__).parent / "react_prompts.json"
+            with open(prompts_path) as f:
+                react_prompts = json.load(f)
 
-        # --- 确保 ALFWorld 游戏数据已下载 ---
-        self._ensure_alfworld_data()
+            # --- 确保 ALFWorld 游戏数据已下载 ---
+            self._ensure_alfworld_data()
 
-        # --- 初始化 ALFWorld 环境 ---
-        workspace = Path(workspace_path)
+            from rdagent.scenarios.rl.autorl_bench.benchmarks.alfworld.data import (
+                _ensure_alfworld_data,
+            )
 
-        from rdagent.scenarios.rl.autorl_bench.benchmarks.alfworld.data import (
-            _ensure_alfworld_data,
-        )
+            alfworld_data = str(_ensure_alfworld_data())
+            os.environ["ALFWORLD_DATA"] = alfworld_data
 
-        alfworld_data = str(_ensure_alfworld_data())
-        os.environ["ALFWORLD_DATA"] = alfworld_data
+            # env_config: 读同目录下官方 base_config.yaml，展开 $ALFWORLD_DATA
+            config_yaml = Path(__file__).parent / "base_config.yaml"
+            with open(config_yaml) as f:
+                import yaml
 
-        # env_config: 读同目录下官方 base_config.yaml，展开 $ALFWORLD_DATA
-        config_yaml = Path(__file__).parent / "base_config.yaml"
-        with open(config_yaml) as f:
-            import yaml
+                env_config = yaml.safe_load(f)
+            env_config = self._expand_env_vars(env_config)
 
-            env_config = yaml.safe_load(f)
-        env_config = self._expand_env_vars(env_config)
+            from alfworld.agents.environment import get_environment
 
-        from alfworld.agents.environment import get_environment
+            split = cfg.get("split", "eval_out_of_distribution")
+            env_type = env_config.get("env", {}).get("type", "AlfredTWEnv")
+            alfred_env = get_environment(env_type)(env_config, train_eval=split)
+            env = alfred_env.init_env(batch_size=1)
 
-        split = cfg.get("split", "eval_out_of_distribution")
-        env_type = env_config.get("env", {}).get("type", "AlfredTWEnv")
-        alfred_env = get_environment(env_type)(env_config, train_eval=split)
-        env = alfred_env.init_env(batch_size=1)
+            num_games = min(env_num, alfred_env.num_games)
+            _log(f"ALFWorld: {num_games} games, max {max_steps} steps, split={split}")
 
-        num_games = min(env_num, alfred_env.num_games)
-        _log(f"ALFWorld: {num_games} games, max {max_steps} steps, split={split}")
+            # --- 评测循环（ReAct 官方逻辑） ---
+            cnts = [0] * 6
+            rs = [0] * 6
 
-        # --- 评测循环（ReAct 官方逻辑） ---
-        cnts = [0] * 6
-        rs = [0] * 6
+            for game_no in range(num_games):
+                ob, info = env.reset()
+                ob = "\n".join(ob[0].split("\n\n")[1:])
+                name = "/".join(info["extra.gamefile"][0].split("/")[-3:-1])
+                _log(f"\n[Game {game_no + 1}/{num_games}] {name}")
 
-        for game_no in range(num_games):
-            ob, info = env.reset()
-            ob = "\n".join(ob[0].split("\n\n")[1:])
-            name = "/".join(info["extra.gamefile"][0].split("/")[-3:-1])
-            _log(f"\n[Game {game_no + 1}/{num_games}] {name}")
+                matched = False
+                for i, (prefix, prompt_key) in enumerate(TASK_PREFIXES.items()):
+                    if name.startswith(prefix):
+                        prompt = (
+                            "Interact with a household to solve a task. Here are two examples.\n"
+                            + react_prompts[f"react_{prompt_key}_1"]
+                            + react_prompts[f"react_{prompt_key}_0"]
+                            + "\nHere is the task.\n"
+                        )
+                        reward, steps = alfworld_run(llm_fn, env, prompt, ob, max_steps)
+                        rs[i] += reward
+                        cnts[i] += 1
+                        matched = True
+                        _log(f"  Result: {'WON' if reward else 'LOST'} ({steps} steps)")
+                        break
 
-            matched = False
-            for i, (prefix, prompt_key) in enumerate(TASK_PREFIXES.items()):
-                if name.startswith(prefix):
-                    prompt = (
-                        "Interact with a household to solve a task. Here are two examples.\n"
-                        + react_prompts[f"react_{prompt_key}_1"]
-                        + react_prompts[f"react_{prompt_key}_0"]
-                        + "\nHere is the task.\n"
-                    )
-                    reward, steps = alfworld_run(llm_fn, env, prompt, ob, max_steps)
-                    rs[i] += reward
-                    cnts[i] += 1
-                    matched = True
-                    _log(f"  Result: {'WON' if reward else 'LOST'} ({steps} steps)")
-                    break
+                if not matched:
+                    _log(f"  WARNING: Unknown task type: {name}, skipping")
+                    continue
 
-            if not matched:
-                _log(f"  WARNING: Unknown task type: {name}, skipping")
-                continue
+                total_r, total_c = sum(rs), sum(cnts)
+                _log(f"  Running: {total_r}/{total_c} = {total_r / max(total_c, 1):.1%}")
 
-            total_r, total_c = sum(rs), sum(cnts)
-            _log(f"  Running: {total_r}/{total_c} = {total_r / max(total_c, 1):.1%}")
+            # --- 汇总结果 ---
+            total_success = sum(rs)
+            total_count = sum(cnts)
+            success_rate = total_success / total_count if total_count > 0 else 0.0
 
-        env.close()
-        llm_cleanup()
+            per_task = {}
+            for (prefix, _), s, c in zip(TASK_PREFIXES.items(), rs, cnts):
+                if c > 0:
+                    per_task[prefix] = {"success": s, "total": c, "rate": s / c}
 
-        # --- 汇总结果 ---
-        total_success = sum(rs)
-        total_count = sum(cnts)
-        success_rate = total_success / total_count if total_count > 0 else 0.0
+            result["score"] = success_rate * 100
+            result["accuracy_summary"] = {
+                "success_count": total_success,
+                "total_count": total_count,
+                "success_rate": success_rate,
+                "per_task": per_task,
+            }
 
-        per_task = {}
-        for (prefix, _), s, c in zip(TASK_PREFIXES.items(), rs, cnts):
-            if c > 0:
-                per_task[prefix] = {"success": s, "total": c, "rate": s / c}
+            _log(f"\nALFWorld done: {total_success}/{total_count} = {success_rate:.2%}")
+            for prefix, stats in per_task.items():
+                _log(f"  {prefix:30s} {stats['success']}/{stats['total']} = {stats['rate']:.0%}")
 
-        result["score"] = success_rate * 100
-        result["accuracy_summary"] = {
-            "success_count": total_success,
-            "total_count": total_count,
-            "success_rate": success_rate,
-            "per_task": per_task,
-        }
-
-        _log(f"\nALFWorld done: {total_success}/{total_count} = {success_rate:.2%}")
-        for prefix, stats in per_task.items():
-            _log(f"  {prefix:30s} {stats['success']}/{stats['total']} = {stats['rate']:.0%}")
-
-        # 恢复 stdout
-        sys.stdout = sys.__stdout__
-
-        return result
+            return result
+        except Exception as e:
+            result["error"] = f"ALFWorld eval failed: {e}"
+            _log(result["error"])
+            return result
+        finally:
+            if env is not None:
+                try:
+                    env.close()
+                except Exception as e:
+                    _log(f"Failed to close ALFWorld env: {e}")
+            if llm_cleanup is not None:
+                try:
+                    llm_cleanup()
+                except Exception as e:
+                    _log(f"Failed to release ALFWorld LLM backend: {e}")
+            sys.stdout = old_stdout
+            tee.close()
 
     @staticmethod
     def _ensure_alfworld_data():
@@ -366,8 +402,8 @@ class ALFWorldEvaluator(BaseEvaluator):
         """递归展开 $ENV_VAR"""
         if isinstance(obj, str):
             return os.path.expandvars(obj)
-        elif isinstance(obj, dict):
+        if isinstance(obj, dict):
             return {k: self._expand_env_vars(v) for k, v in obj.items()}
-        elif isinstance(obj, list):
+        if isinstance(obj, list):
             return [self._expand_env_vars(x) for x in obj]
         return obj

--- a/rdagent/scenarios/rl/autorl_bench/core/__init__.py
+++ b/rdagent/scenarios/rl/autorl_bench/core/__init__.py
@@ -37,6 +37,7 @@ AutoRL-Bench Core Module
 from .evaluator import (
     BaseEvaluator,
     EvalResult,
+    validate_eval_result,
 )
 from .metrics import run_workspace_metrics
 from .opencompass import OpenCompassEvaluator
@@ -50,6 +51,7 @@ from .utils import (
     get_baseline_score,
     init_run_meta,
     kill_process_group,
+    kill_process_tree,
     print_summary,
     read_run_meta,
     set_baseline_to_server,
@@ -63,6 +65,7 @@ __all__ = [
     "EvalResult",
     # 评测器
     "BaseEvaluator",
+    "validate_eval_result",
     "OpenCompassEvaluator",
     # 服务
     "create_grading_server",
@@ -79,6 +82,7 @@ __all__ = [
     "detect_driver_model",
     "print_summary",
     "kill_process_group",
+    "kill_process_tree",
     "init_run_meta",
     "update_run_meta",
     "read_run_meta",

--- a/rdagent/scenarios/rl/autorl_bench/core/evaluator.py
+++ b/rdagent/scenarios/rl/autorl_bench/core/evaluator.py
@@ -7,6 +7,7 @@ AutoRL-Bench Evaluator Base Class
 """
 
 from abc import ABC, abstractmethod
+from numbers import Real
 from pathlib import Path
 from typing import Any, Dict
 
@@ -149,3 +150,25 @@ class BaseEvaluator(ABC):
             "score": 0.0,
             "accuracy_summary": {},
         }
+
+
+def validate_eval_result(result: Dict[str, Any]) -> tuple[bool, str | None]:
+    """Return whether an evaluator result represents a completed evaluation."""
+
+    error = result.get("error")
+    if error:
+        return False, str(error)
+
+    score = result.get("score")
+    if not isinstance(score, Real) or isinstance(score, bool):
+        return False, f"non-numeric score: {score!r}"
+
+    summary = result.get("accuracy_summary")
+    if not isinstance(summary, dict) or not summary:
+        return False, "missing accuracy_summary for completed evaluation"
+
+    nested_error = summary.get("error")
+    if nested_error:
+        return False, str(nested_error)
+
+    return True, None

--- a/rdagent/scenarios/rl/autorl_bench/core/opencompass.py
+++ b/rdagent/scenarios/rl/autorl_bench/core/opencompass.py
@@ -118,8 +118,7 @@ class OpenCompassEvaluator(BaseEvaluator):
             error_msg = proc.stderr[:1000] if proc.stderr else proc.stdout[:1000] if proc.stdout else "No output"
             logger.warning(f"OpenCompass failed: {error_msg}")
             result["error"] = (
-                f"OpenCompass exit code: {proc.returncode} "
-                f"(stdout: {stdout_log}, stderr: {stderr_log})"
+                f"OpenCompass exit code: {proc.returncode} " f"(stdout: {stdout_log}, stderr: {stderr_log})"
             )
             result["raw_output"] = error_msg
             return result

--- a/rdagent/scenarios/rl/autorl_bench/core/opencompass.py
+++ b/rdagent/scenarios/rl/autorl_bench/core/opencompass.py
@@ -4,6 +4,7 @@ OpenCompass Evaluator
 用于所有使用 OpenCompass 评测的 benchmark（gsm8k, math 等）。
 """
 
+import os
 import subprocess
 from pathlib import Path
 from typing import Any, Dict
@@ -97,17 +98,29 @@ class OpenCompassEvaluator(BaseEvaluator):
 
         # 运行 OpenCompass
         cmd = ["opencompass", str(config_path), "--work-dir", str(work_dir)]
+        oc_env = os.environ.copy()
+        oc_env.setdefault("FLASHINFER_DISABLE_VERSION_CHECK", "1")
+        oc_env.setdefault("VLLM_ENFORCE_EAGER", "1")
+        oc_env.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+        stdout_log = work_dir / "opencompass_stdout.log"
+        stderr_log = work_dir / "opencompass_stderr.log"
 
         try:
-            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=7200)
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=7200, env=oc_env)
         except subprocess.TimeoutExpired:
             result["error"] = "OpenCompass timeout (7200s)"
             return result
 
+        stdout_log.write_text(proc.stdout or "", encoding="utf-8", errors="replace")
+        stderr_log.write_text(proc.stderr or "", encoding="utf-8", errors="replace")
+
         if proc.returncode != 0:
             error_msg = proc.stderr[:1000] if proc.stderr else proc.stdout[:1000] if proc.stdout else "No output"
             logger.warning(f"OpenCompass failed: {error_msg}")
-            result["error"] = f"OpenCompass exit code: {proc.returncode}"
+            result["error"] = (
+                f"OpenCompass exit code: {proc.returncode} "
+                f"(stdout: {stdout_log}, stderr: {stderr_log})"
+            )
             result["raw_output"] = error_msg
             return result
 

--- a/rdagent/scenarios/rl/autorl_bench/core/utils.py
+++ b/rdagent/scenarios/rl/autorl_bench/core/utils.py
@@ -22,27 +22,62 @@ from rdagent.scenarios.rl.autorl_bench.conf import (
     get_data_dir,
     get_models_dir,
 )
+from rdagent.scenarios.rl.autorl_bench.core.evaluator import validate_eval_result
 
 
-def kill_process_group(proc: "subprocess.Popen") -> None:
-    """尽力杀掉进程组：SIGTERM → SIGKILL → proc.kill()"""
+def kill_process_tree(proc: "subprocess.Popen") -> None:
+    """Kill a process session first, then its process group as a fallback."""
     import signal as _signal
 
     if proc.poll() is not None:
         return
+
+    try:
+        sid = os.getsid(proc.pid)
+    except OSError:
+        sid = None
+
     for sig in (_signal.SIGTERM, _signal.SIGKILL):
+        if sid:
+            try:
+                ps_output = subprocess.check_output(["ps", "-eo", "pid=,sid="], text=True)
+                for line in ps_output.splitlines():
+                    parts = line.split()
+                    if len(parts) != 2:
+                        continue
+                    pid_s, sid_s = parts
+                    if int(sid_s) == sid:
+                        try:
+                            os.kill(int(pid_s), sig)
+                        except (ProcessLookupError, OSError):
+                            pass
+            except (OSError, subprocess.SubprocessError, ValueError):
+                pass
+
+            try:
+                os.killpg(sid, sig)
+            except (ProcessLookupError, OSError):
+                pass
+
         try:
             os.killpg(os.getpgid(proc.pid), sig)
+        except (ProcessLookupError, OSError):
+            pass
+
+        try:
             proc.wait(timeout=10)
-            return
-        except ProcessLookupError:
             return
         except subprocess.TimeoutExpired:
             continue
-        except OSError:
-            break
-    proc.kill()
+
+    try:
+        proc.kill()
+    except (ProcessLookupError, OSError):
+        pass
     proc.wait()
+
+
+kill_process_group = kill_process_tree
 
 
 # ============================================================
@@ -178,23 +213,24 @@ def get_baseline_score(
         test_range=test_range,
     )
 
+    ok, error = validate_eval_result(result)
     score = result.get("score", 0.0)
-    error = result.get("error")
     logger.info(f"Baseline score: {score}")
 
-    # Only cache successful evaluations — failed ones should be retried next time
-    if not error:
-        cache_file.parent.mkdir(parents=True, exist_ok=True)
-        cache_data = {
-            "task": task,
-            "model_name": model_name,
-            "score": score,
-            "test_range": test_range,
-            "timestamp": datetime.now().isoformat(),
-        }
-        cache_file.write_text(json.dumps(cache_data, indent=2, ensure_ascii=False))
-    else:
+    if not ok:
         logger.warning(f"Baseline evaluation failed ({error}), result NOT cached")
+        raise RuntimeError(f"Baseline evaluation failed for {task}: {error}")
+
+    score = float(score)
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_data = {
+        "task": task,
+        "model_name": model_name,
+        "score": score,
+        "test_range": test_range,
+        "timestamp": datetime.now().isoformat(),
+    }
+    cache_file.write_text(json.dumps(cache_data, indent=2, ensure_ascii=False))
 
     return score
 

--- a/rdagent/scenarios/rl/autorl_bench/test/test_fixes.py
+++ b/rdagent/scenarios/rl/autorl_bench/test/test_fixes.py
@@ -1,17 +1,16 @@
 """
-测试 B1-B4 修复
+测试 AutoRL-Bench RL 修复
 
 验证:
-  B1: LoRA adapter 自动检测
-  B2: 评测锁（串行化 GPU 访问）
-  B3: model_path 去重缓存
-  B4: error 字段透传
+  - LoRA adapter 拒绝与 OpenCompass vLLM 环境变量
+  - baseline 失败不再变成 0.0
+  - ALFWorld prompt 截断
+  - 评测锁、model_path 去重缓存、error 字段透传
 
 运行: python -m rdagent.scenarios.rl.autorl_bench.test.test_fixes
 """
 
 import json
-import os
 import sys
 import tempfile
 import threading
@@ -34,10 +33,10 @@ def report(name: str, ok: bool, detail: str = ""):
 
 
 # ============================================================
-# B1: LoRA adapter 自动检测
+# B1: LoRA adapter 拒绝 + OpenCompass env 透传
 # ============================================================
 def test_b1_lora_detection():
-    print("\n=== B1: LoRA adapter detection ===")
+    print("\n=== B1: LoRA rejection + OpenCompass env ===")
     from rdagent.scenarios.rl.autorl_bench.core.opencompass import OpenCompassEvaluator
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -82,33 +81,18 @@ def test_b1_lora_detection():
                 workspace_path=tmpdir,
                 model_name="test-model",
             )
-            if mock_run.called:
-                config_path = Path(tmpdir) / "opencompass_config.py"
-                if config_path.exists():
-                    content = config_path.read_text()
-                    report(
-                        "LoRA detected → is_lora=True in config",
-                        "enable_lora=True" in content,
-                        f"config has enable_lora={'enable_lora=True' in content}",
-                    )
-                    report(
-                        "lora_path set in config", "lora_path=" in content, f"lora_path found={'lora_path=' in content}"
-                    )
-                    report(
-                        "model_path points to base model",
-                        str(base_model_dir) in content,
-                        f"base_model in config={str(base_model_dir) in content}",
-                    )
-                else:
-                    report("OpenCompass config generated", False, "config file not found")
-            else:
-                report("OpenCompass was called", False, "subprocess.run not called")
+            report(
+                "LoRA adapter rejected",
+                "error" in result and "LoRA adapter detected" in result["error"],
+                result.get("error", "no error"),
+            )
+            report("OpenCompass not called for adapter", not mock_run.called)
 
         # Case 2: adapter_config.json with missing base model
         bad_adapter_dir = Path(tmpdir) / "bad_lora"
         bad_adapter_dir.mkdir()
         (bad_adapter_dir / "adapter_config.json").write_text(
-            json.dumps({"base_model_name_or_path": "/nonexistent/model"})
+            json.dumps({"base_model_name_or_path": "/nonexistent/model"}),
         )
         result = evaluator.run_eval(
             model_path=str(bad_adapter_dir),
@@ -116,12 +100,12 @@ def test_b1_lora_detection():
             model_name="test-model",
         )
         report(
-            "Missing base model → returns error",
-            "error" in result and "not found" in result["error"],
+            "Bad LoRA adapter rejected before evaluation",
+            "error" in result and "LoRA adapter detected" in result["error"],
             result.get("error", "no error"),
         )
 
-        # Case 3: normal model (no adapter_config.json) — should NOT set is_lora
+        # Case 3: normal model (no adapter_config.json) — should run OpenCompass with vLLM env
         normal_dir = Path(tmpdir) / "normal_model"
         normal_dir.mkdir()
         (normal_dir / "config.json").write_text("{}")
@@ -160,6 +144,83 @@ def test_b1_lora_detection():
                     "enable_lora" not in content,
                     f"enable_lora absent={'enable_lora' not in content}",
                 )
+                report(
+                    "OpenCompass template sets enforce_eager=True",
+                    "enforce_eager=True" in content,
+                    f"enforce_eager found={'enforce_eager=True' in content}",
+                )
+            else:
+                report("OpenCompass config generated", False, "config file not found")
+
+            env = mock_run.call_args.kwargs.get("env", {}) if mock_run.call_args else {}
+            report("OpenCompass env VLLM_ENFORCE_EAGER=1", env.get("VLLM_ENFORCE_EAGER") == "1")
+            report("OpenCompass env worker method=spawn", env.get("VLLM_WORKER_MULTIPROC_METHOD") == "spawn")
+
+
+def test_baseline_integrity():
+    print("\n=== Baseline integrity ===")
+    from rdagent.scenarios.rl.autorl_bench.core.evaluator import validate_eval_result
+    from rdagent.scenarios.rl.autorl_bench.core.utils import get_baseline_score
+
+    report(
+        "validate_eval_result accepts completed result",
+        validate_eval_result({"score": 1.0, "accuracy_summary": {"accuracy": 1.0}})[0],
+    )
+    ok, error = validate_eval_result({"score": 0.0, "accuracy_summary": {}})
+    report("validate_eval_result rejects empty summary", not ok and "missing accuracy_summary" in error, str(error))
+    ok, error = validate_eval_result({"score": 0.0, "error": "GPU OOM", "accuracy_summary": {}})
+    report("validate_eval_result rejects top-level error", not ok and "GPU OOM" in error, str(error))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_dir = Path(tmpdir) / "cache"
+        mock_evaluator = MagicMock()
+        mock_evaluator.run_eval.return_value = {
+            "score": 12.5,
+            "accuracy_summary": {"accuracy": 12.5},
+        }
+        with (
+            patch("rdagent.scenarios.rl.autorl_bench.core.utils.get_baseline_cache_dir", return_value=cache_dir),
+            patch("rdagent.scenarios.rl.autorl_bench.benchmarks.get_evaluator", return_value=mock_evaluator),
+        ):
+            score = get_baseline_score("gsm8k", "test/model", "/tmp/model", tmpdir, force_rerun=True)
+            report("Successful baseline is cached", score == 12.5 and any(cache_dir.glob("*.json")))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_dir = Path(tmpdir) / "cache"
+        mock_evaluator = MagicMock()
+        mock_evaluator.run_eval.return_value = {
+            "score": 0.0,
+            "error": "GPU OOM",
+            "accuracy_summary": {},
+        }
+        with (
+            patch("rdagent.scenarios.rl.autorl_bench.core.utils.get_baseline_cache_dir", return_value=cache_dir),
+            patch("rdagent.scenarios.rl.autorl_bench.benchmarks.get_evaluator", return_value=mock_evaluator),
+        ):
+            try:
+                get_baseline_score("gsm8k", "test/model", "/tmp/model", tmpdir, force_rerun=True)
+                raised = False
+            except RuntimeError:
+                raised = True
+            report("Failed baseline raises instead of returning 0.0", raised)
+            report("Failed baseline is not cached", not any(cache_dir.glob("*.json")))
+
+
+def test_alfworld_prompt_truncation():
+    print("\n=== ALFWorld prompt truncation ===")
+    from rdagent.scenarios.rl.autorl_bench.benchmarks.alfworld.eval import _truncate_prompt_to_fit
+
+    class ToyTokenizer:
+        def encode(self, text):
+            return text.split()
+
+        def decode(self, token_ids):
+            return " ".join(token_ids)
+
+    tokenizer = ToyTokenizer()
+    prompt = " ".join(str(i) for i in range(10))
+    truncated = _truncate_prompt_to_fit(prompt, tokenizer, max_context_tokens=6, max_output_tokens=2)
+    report("Prompt is trimmed from the left", truncated == "7 8 9", truncated)
 
 
 # ============================================================
@@ -200,7 +261,6 @@ def test_b2b3_lock_and_cache():
             (model_a / "config.json").write_text("{}")
             (model_b / "config.json").write_text("{}")
 
-            threads = []
             results = []
 
             def submit_wrapper(mp):
@@ -240,7 +300,7 @@ def test_b2b3_lock_and_cache():
             fail_model.mkdir()
             (fail_model / "config.json").write_text("{}")
 
-            r1 = server.submit(str(fail_model))
+            server.submit(str(fail_model))
             report(
                 "B3: failed eval not cached",
                 str(fail_model.resolve()) not in server._eval_cache,
@@ -279,7 +339,6 @@ def test_b4_error_passthrough():
 
     # Test _parse_results with non-numeric values (B4 in opencompass)
     import pandas as pd
-
     from rdagent.scenarios.rl.autorl_bench.core.opencompass import OpenCompassEvaluator
 
     config = MagicMock()
@@ -306,6 +365,8 @@ def test_b4_error_passthrough():
 
 def main():
     test_b1_lora_detection()
+    test_baseline_integrity()
+    test_alfworld_prompt_truncation()
     test_b2b3_lock_and_cache()
     test_b4_error_passthrough()
 

--- a/rdagent/scenarios/rl/autorl_bench/test/test_fixes.py
+++ b/rdagent/scenarios/rl/autorl_bench/test/test_fixes.py
@@ -208,7 +208,9 @@ def test_baseline_integrity():
 
 def test_alfworld_prompt_truncation():
     print("\n=== ALFWorld prompt truncation ===")
-    from rdagent.scenarios.rl.autorl_bench.benchmarks.alfworld.eval import _truncate_prompt_to_fit
+    from rdagent.scenarios.rl.autorl_bench.benchmarks.alfworld.eval import (
+        _truncate_prompt_to_fit,
+    )
 
     class ToyTokenizer:
         def encode(self, text):
@@ -339,6 +341,7 @@ def test_b4_error_passthrough():
 
     # Test _parse_results with non-numeric values (B4 in opencompass)
     import pandas as pd
+
     from rdagent.scenarios.rl.autorl_bench.core.opencompass import OpenCompassEvaluator
 
     config = MagicMock()


### PR DESCRIPTION
## Summary

  This PR hardens the AutoRL-Bench RL evaluators by backporting a small set
  of targeted fixes:

  - Fix ALFWorld vLLM evaluation crashes from overlong ReAct history by
  truncating prompts to fit the configured context window.
  - Ensure ALFWorld restores stdout and cleans up the environment / vLLM
  backend even when evaluation fails.
  - Propagate vLLM-safe environment variables to OpenCompass subprocesses
  and set `enforce_eager=True` in the OpenCompass template.
  - Prevent failed baseline evaluations from silently becoming cached or
  returned as valid `0.0` scores.
  - Improve timeout cleanup by killing the process session/tree, while
  keeping `kill_process_group` as a compatibility alias.

  ## Validation

  - `python -m py_compile rdagent/scenarios/rl/autorl_bench/benchmarks/
  alfworld/eval.py rdagent/scenarios/rl/autorl_bench/core/evaluator.py
  rdagent/scenarios/rl/autorl_bench/core/utils.py rdagent/scenarios/rl/
  autorl_bench/core/opencompass.py rdagent/scenarios/rl/autorl_bench/core/
  __init__.py rdagent/scenarios/rl/autorl_bench/test/test_fixes.py`
  - `ruff check --no-fix --select F,E9 rdagent/scenarios/rl/autorl_bench/
  benchmarks/alfworld/eval.py rdagent/scenarios/rl/autorl_bench/core/
  evaluator.py rdagent/scenarios/rl/autorl_bench/core/utils.py rdagent/
  scenarios/rl/autorl_bench/core/opencompass.py rdagent/scenarios/rl/
  autorl_bench/core/__init__.py rdagent/scenarios/rl/autorl_bench/test/
  test_fixes.py`
  - `/tmp/rdagent-test-venv/bin/python -m
  rdagent.scenarios.rl.autorl_bench.test.test_fixes`

  Result: `24 passed, 0 failed`.

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1402.org.readthedocs.build/en/1402/

<!-- readthedocs-preview RDAgent end -->