### PR TITLE
fix(io): force utf-8 encoding when loading non-yaml templates

### DIFF
--- a/rdagent/utils/agent/tpl.py
+++ b/rdagent/utils/agent/tpl.py
@@ -72,7 +72,13 @@ def load_content(uri: str, caller_dir: Path | None = None, ftype: str = "yaml") 
                     yaml_content = yaml_content[key]
                 return yaml_content
 
-            return file_path.read_text()
+            # Force UTF-8 so non-YAML templates (.md, .txt, .py, ...) decode
+            # consistently across platforms. Without an explicit encoding,
+            # ``Path.read_text`` falls back to ``locale.getpreferredencoding``,
+            # which is ``cp1252`` / ``gbk`` / etc on non-UTF-8 Windows hosts
+            # and raises ``UnicodeDecodeError`` on any non-ASCII byte the
+            # template happens to carry. Reported in issue #939.
+            return file_path.read_text(encoding="utf-8")
         except FileNotFoundError:
             continue  # the file does not exist, so goto the next loop.
         except KeyError:


### PR DESCRIPTION
## Summary

Resolves #939.

`Tpl.load_content` falls through to `file_path.read_text()` for non-YAML templates (`.md`, `.txt`, `.py`, ...). Without an explicit encoding, `Path.read_text` uses `locale.getpreferredencoding`, which is `cp1252` / `gbk` / etc on non-UTF-8 Windows hosts. Any non-ASCII byte the template happens to carry then raises a `UnicodeDecodeError` that bubbles up through `fin_factor` / `fin_quant` / `fin_model` startup.

Aligns the non-YAML branch with the YAML branch immediately above it which already passes `encoding="utf-8"`.

## Test plan

- [x] Python AST parse clean on the patched file.
- [x] Two `read_text` / `open` call sites in `load_content` (YAML and fallback) now agree on UTF-8 encoding semantics.

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1414.org.readthedocs.build/en/1414/

<!-- readthedocs-preview RDAgent end -->