### PR TITLE
chore: fix 'paramter' typo in qlib_rd_loop docstrings

### DIFF
--- a/rdagent/app/qlib_rd_loop/factor.py
+++ b/rdagent/app/qlib_rd_loop/factor.py
@@ -44,7 +44,7 @@ def main(
 
     .. code-block:: python
 
-        dotenv run -- python rdagent/app/qlib_rd_loop/factor.py $LOG_PATH/__session__/1/0_propose  --step_n 1   # `step_n` is a optional paramter
+        dotenv run -- python rdagent/app/qlib_rd_loop/factor.py $LOG_PATH/__session__/1/0_propose  --step_n 1   # `step_n` is a optional parameter
 
     """
     if not checkout_path is None:

--- a/rdagent/app/qlib_rd_loop/model.py
+++ b/rdagent/app/qlib_rd_loop/model.py
@@ -31,7 +31,7 @@ def main(
 
     .. code-block:: python
 
-        dotenv run -- python rdagent/app/qlib_rd_loop/model.py $LOG_PATH/__session__/1/0_propose  --step_n 1   # `step_n` is a optional paramter
+        dotenv run -- python rdagent/app/qlib_rd_loop/model.py $LOG_PATH/__session__/1/0_propose  --step_n 1   # `step_n` is a optional parameter
 
     """
     if path is None:

--- a/rdagent/app/qlib_rd_loop/quant.py
+++ b/rdagent/app/qlib_rd_loop/quant.py
@@ -141,7 +141,7 @@ def main(
     Auto R&D Evolving loop for fintech factors.
     You can continue running session by
     .. code-block:: python
-        dotenv run -- python rdagent/app/qlib_rd_loop/quant.py $LOG_PATH/__session__/1/0_propose  --step_n 1   # `step_n` is a optional paramter
+        dotenv run -- python rdagent/app/qlib_rd_loop/quant.py $LOG_PATH/__session__/1/0_propose  --step_n 1   # `step_n` is a optional parameter
     """
     if path is None:
         quant_loop = QuantRDLoop(QUANT_PROP_SETTING)


### PR DESCRIPTION
## Summary

Three entry-point modules under `rdagent/app/qlib_rd_loop/` (`factor.py`, `model.py`, `quant.py`) advertise `\`step_n\` is a optional paramter` in their resume-from-session docstrings. Fix typo to `parameter`.

Docstring-only; no behavior change.

## Test plan

- [x] `python3 -m ast` parses the three files cleanly.
- [x] Only inline-comment text changes; no executable paths touched.

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1415.org.readthedocs.build/en/1415/

<!-- readthedocs-preview RDAgent end -->