### PR TITLE
chore: fix comment typos in core and utils

### DIFF
--- a/rdagent/core/evolving_agent.py
+++ b/rdagent/core/evolving_agent.py
@@ -151,7 +151,7 @@ class RAGEvoAgent(EvoAgent[RAGEvaluator, ASpecificEvolvableSubjects], Generic[AS
                     queried_knowledge = self.rag.query(evo, self.evolving_trace)
 
                 # 2. evolve:
-                # A compelete solution of an evo can be break down into multiple evolving steps.
+                # A complete solution of an evo can be broken down into multiple evolving steps.
                 # Each evolving step can be evaluated separately.
                 # Assumptions:
                 # - if we want to stop on some point of the implementation, we must have a according evaluator (Otherwise, It is meaningless to stop)

--- a/rdagent/core/proposal.py
+++ b/rdagent/core/proposal.py
@@ -69,7 +69,7 @@ class ExperimentFeedback(Feedback):
         self.eda_improvement = eda_improvement
         self.reason = reason
         # Exception is not None means failing to generate runnable experiments due to exception.
-        # Runable reuslts are not always good.
+        # Runnable results are not always good.
         self.exception: Exception | None = (
             exception  # if the experiment raises exception, it will be integrated into part of the feedback.
         )
@@ -165,7 +165,7 @@ class Trace(Generic[ASpecificScen, ASpecificKB]):
         self.idx2loop_id: dict[int, int] = {}
 
         # Design discussion:
-        # - If we unifiy the loop_id and the enqueue id, we will have less recognition burden.
+        # - If we unify the loop_id and the enqueue id, we will have less recognition burden.
         # - If we use different id for loop and enqueue, we don't have to handle the placeholder logic.
         # END: graph structure -------------------------
 

--- a/rdagent/utils/agent/tpl.py
+++ b/rdagent/utils/agent/tpl.py
@@ -104,7 +104,7 @@ class RDAT:
 
             the loaded content will be saved in `self.template`
 
-        Content loading prioirties:
+        Content loading priorities:
         -.a.b.c has the highest priority
         - <current directory>/a/b/c.yaml via a.b.c  (So you can make customization under current directory)
         - <RD-Agent pack directory>/a/b/c.yaml via a.b.c  (RD-Agent provides the default template)

--- a/rdagent/utils/workflow/loop.py
+++ b/rdagent/utils/workflow/loop.py
@@ -46,7 +46,7 @@ class LoopMeta(type):
         steps = []
         for base in bases:
             for step in LoopMeta._get_steps(base.__bases__) + getattr(base, "steps", []):
-                if step not in steps and step not in ["load", "dump"]:  # incase user override the load/dump method
+                if step not in steps and step not in ["load", "dump"]:  # in case user overrides the load/dump method
                     steps.append(step)
         return steps
 
@@ -66,7 +66,7 @@ class LoopMeta(type):
         for name, attr in attrs.items():
             if not name.startswith("_") and callable(attr) and not isinstance(attr, type):
                 # NOTE: `not isinstance(attr, type)` is trying to exclude class type attribute
-                if name not in steps and name not in ["load", "dump"]:  # incase user override the load/dump method
+                if name not in steps and name not in ["load", "dump"]:  # in case user overrides the load/dump method
                     # NOTE: if we override the step in the subclass
                     # Then it is not the new step. So we skip it.
                     steps.append(name)
@@ -148,7 +148,7 @@ class LoopBase:
         # NOTE:
         # (1) we assume the record step is always the last step to modify the global environment,
         #     so we set the limit to 1 to avoid race condition
-        # (2) Because we support (-1,) as local selection; So it is hard to align a) the comparision target in `feedbck`
+        # (2) Because we support (-1,) as local selection; So it is hard to align a) the comparison target in `feedback`
         #     and b) parent node in `record`; So we prevent parallelism in `feedback` and `record` to avoid inconsistency
         if step_name in ("record", "feedback"):
             limit = 1


### PR DESCRIPTION
## Summary

Sweep of inline-comment / docstring typos surfaced by `codespell`.

- `rdagent/core/evolving_agent.py`: `compelete` -> `complete` (and tidy `be break down` -> `be broken down` in the same line).
- `rdagent/core/proposal.py`: `Runable reuslts` -> `Runnable results`; `unifiy the loop_id` -> `unify the loop_id`.
- `rdagent/utils/agent/tpl.py`: `Content loading prioirties` -> `Content loading priorities`.
- `rdagent/utils/workflow/loop.py`: two `incase user override` notes -> `in case user overrides`; one `comparision target in feedbck` -> `comparison target in feedback`.

Comment/docstring-only; no behavior change.

## Test plan

- [x] `python3 -m ast` parses all four files cleanly.
- [x] Diff shows only inline-comment / docstring lines.

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1416.org.readthedocs.build/en/1416/

<!-- readthedocs-preview RDAgent end -->