### PR TITLE
fix(ci): instantiate CIEvoStr with a Scenario, add minimal CIScen

### DIFF
--- a/rdagent/app/CI/run.py
+++ b/rdagent/app/CI/run.py
@@ -32,7 +32,9 @@ from rdagent.core.evolving_framework import (
     Feedback,
     Knowledge,
 )
+from rdagent.core.experiment import Task
 from rdagent.core.prompts import Prompts
+from rdagent.core.scenario import Scenario
 from rdagent.oai.llm_utils import APIBackend
 
 py_parser = Parser(Language(tree_sitter_python.language()))
@@ -428,6 +430,35 @@ class MultiEvaluator(Evaluator):
         return CIFeedback(errors=all_errors)
 
 
+class CIScen(Scenario):
+    """Minimal scenario for the CI linting workflow.
+
+    `EvolvingStrategy` requires a `Scenario` instance, but the CI run loop only
+    needs the lint-rule prompts in `CI_prompts` — it never inspects scenario
+    state. The descriptions below are kept short and CI-specific so the
+    `Scenario` API contract is honoured without dragging in unrelated config.
+    """
+
+    @property
+    def background(self) -> str:
+        return "Automated code-quality repair loop driven by ruff/mypy diagnostics."
+
+    @property
+    def rich_style_description(self) -> str:
+        return "[bold]RD-Agent CI[/bold]: iteratively fix lint and type errors."
+
+    def get_scenario_all_desc(
+        self,
+        task: Task | None = None,
+        filtered_tag: str | None = None,
+        simple_background: bool | None = None,
+    ) -> str:
+        return self.background
+
+    def get_runtime_environment(self) -> str:
+        return ""
+
+
 class CIEvoStr(EvolvingStrategy):
     def evolve(  # noqa: C901, PLR0912, PLR0915
         self,
@@ -726,7 +757,7 @@ start_timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%m%d%H%
 repo = Repo(DIR, excludes=excludes)
 # evaluator = MultiEvaluator(MypyEvaluator(), RuffEvaluator())
 evaluator = RuffEvaluator()
-estr = CIEvoStr()
+estr = CIEvoStr(scen=CIScen())
 ea = CIEvoAgent(estr)
 ea.multistep_evolve(repo, evaluator)
 while True:


### PR DESCRIPTION
### Summary

Closes #1329.

`python rdagent/app/CI/run.py <path>` aborts at startup with:

```
File "rdagent/app/CI/run.py", line 730, in <module>
    estr = CIEvoStr()
TypeError: EvolvingStrategy.__init__() missing 1 required positional argument: 'scen'
```

### Root cause

`EvolvingStrategy.__init__(self, scen: Scenario)` (`rdagent/core/evolving_framework.py:61-63`) requires a `Scenario` instance. `CIEvoStr` inherits without overriding `__init__`, but the script's module-level launch (`rdagent/app/CI/run.py:729`) constructs it with no arguments, so the call fails before the lint loop ever runs.

`CIEvoStr.evolve` itself never reads `self.scen` — the linting workflow is driven entirely by `CI_prompts` and ruff/mypy output — so the missing argument is purely a contract violation, not a logical dependency.

### Change

`rdagent/app/CI/run.py`:

- Add a small local `CIScen(Scenario)` class with the four abstract methods (`background`, `rich_style_description`, `get_scenario_all_desc`, `get_runtime_environment`) returning short CI-appropriate strings. Keeping it local avoids pulling a CI-specific scenario into `rdagent/scenarios/` where it would have no other consumer.
- Pass an instance through at the call site: `estr = CIEvoStr(scen=CIScen())`.

### Verification

- `python -m py_compile rdagent/app/CI/run.py` clean.
- `ast.parse` clean.
- Approach matches the suggestion in the issue body ("explicitly create and pass in" a Scenario rather than calling with no arguments).