### PR TITLE
fix(env): keep container bind paths POSIX in normalize_volumes

### DIFF
--- a/rdagent/utils/env.py
+++ b/rdagent/utils/env.py
@@ -22,7 +22,7 @@ from abc import abstractmethod
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from types import MappingProxyType
 from typing import (
     Any,
@@ -113,26 +113,35 @@ def cleanup_container(container: docker.models.containers.Container | None, cont
             logger.warning(f"Failed to cleanup{context_str} container {container.id}: {cleanup_error}")
 
 
-# Normalize all bind paths in volumes to absolute paths using the workspace (working_dir).
+# Normalize all bind paths in volumes to absolute paths.
+# Host keys are resolved to native absolute paths so Docker on Windows
+# receives `C:\...` rather than a POSIX-style key, while container-side
+# paths are forced to POSIX so they don't get rewritten as `C:\workspace\...`
+# on Windows (which produced "too many colons" mount errors — see #1064).
 def normalize_volumes(vols: dict[str, str | dict[str, str]], working_dir: str) -> dict:
     abs_vols: dict[str, str | dict[str, str]] = {}
 
-    def to_abs(path: str) -> str:
-        # Converts a relative path to an absolute path using the workspace (working_dir).
-        return os.path.abspath(os.path.join(working_dir, path)) if not os.path.isabs(path) else path
+    def to_abs_host(path: str) -> str:
+        return os.path.abspath(path)
+
+    def to_abs_posix_container(path: str) -> str:
+        # Container paths are always POSIX. Absolute → keep, relative → resolve
+        # against the container-side working directory.
+        if os.path.isabs(path):
+            return str(PurePosixPath(path))
+        return str(PurePosixPath(working_dir) / path)
 
     for lp, vinfo in vols.items():
         # Support both:
         # 1. {'host_path': {'bind': 'container_path', ...}}
         # 2. {'host_path': 'container_path'}
+        abs_host = to_abs_host(lp)
         if isinstance(vinfo, dict):
-            # abs_vols = cast(dict[str, dict[str, str]], abs_vols)
             vinfo = vinfo.copy()
-            vinfo["bind"] = to_abs(vinfo["bind"])
-            abs_vols[lp] = vinfo
+            vinfo["bind"] = to_abs_posix_container(vinfo["bind"])
+            abs_vols[abs_host] = vinfo
         else:
-            # abs_vols = cast(dict[str, str], abs_vols)
-            abs_vols[lp] = to_abs(vinfo)
+            abs_vols[abs_host] = to_abs_posix_container(vinfo)
     return abs_vols
 
 


### PR DESCRIPTION
### Summary

Closes #1064.

On Windows hosts, `rdagent` fails to start any workflow with a Docker `500 Internal Server Error: invalid mount config ... mount denied`. The reporter and two follow-up commenters on the issue traced the failure to `normalize_volumes` in `rdagent/utils/env.py`.

### Root cause

`normalize_volumes` passed both the host key (e.g. `./work_dir`) and the container-side path (e.g. `/workspace/qlib_workspace`) through the same helper:

```python
def to_abs(path: str) -> str:
    return os.path.abspath(os.path.join(working_dir, path)) if not os.path.isabs(path) else path
```

On Windows, `os.path.abspath('/workspace/qlib_workspace')` rewrites the container path as `C:\workspace\qlib_workspace`, so the final Docker bind string becomes

```
C:\Users\...\work_dir:C:\workspace\qlib_workspace:rw
```

which contains too many colons for Docker to parse, producing the mount-denied error in the report. The host side, meanwhile, was never normalised, so a relative or POSIX-style `lp` entry coming in from config silently survived to the Docker SDK call.

### Change

`rdagent/utils/env.py`:

- Split the helper in two:
  - `to_abs_host(path)` → `os.path.abspath(path)`. The host key is always resolved to a native absolute path, so Windows sees `C:\...` and Linux/macOS see the usual POSIX form.
  - `to_abs_posix_container(path)` → `str(PurePosixPath(path))` for absolute container paths, `str(PurePosixPath(working_dir) / path)` for relative ones. `PurePosixPath` keeps forward slashes regardless of the host OS, which is what the container actually sees.
- Add `PurePosixPath` to the existing `pathlib` import.

### Verification

- `python -m py_compile rdagent/utils/env.py` clean.
- Hand-traced three cases (`host abs + container abs`, `host relative + container abs`, `host relative + container relative`) — host always lands at a native absolute path; container always lands at a POSIX path.
- The same fix shape was validated by users `@arcayi` and `@lemondy` on the issue thread ("thanks. it solve the problem"), so this is the form the community has run against on Windows.

### Notes

The patch keeps current behaviour identical on Linux/macOS — every example I traced produced the same dict the old code did. The only intentional difference is that the host key is now always absolute, which is what the Docker SDK requires for bind mounts anyway.

Fixes #1064

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1418.org.readthedocs.build/en/1418/

<!-- readthedocs-preview RDAgent end -->