### PR TITLE
docs: add Tuning Engines LiteLLM config

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,17 @@ More details can be found in the [development setup](https://rdagent.readthedocs
   OPENAI_API_KEY=<replace_with_your_openai_api_key>
   ```
 
+  *Configuration Example: `Tuning Engines` Setup :*
+
+  ```bash
+  cat << EOF  > .env
+  # Route chat and embedding calls through the Tuning Engines OpenAI-compatible endpoint.
+  CHAT_MODEL=openai/<your_chat_model_alias>
+  EMBEDDING_MODEL=openai/<your_embedding_model_alias>
+  OPENAI_API_BASE=https://api.tuningengines.com/v1
+  OPENAI_API_KEY=<replace_with_your_tuning_engines_inference_key>
+  ```
+
   *Configuration Example: `Azure OpenAI` Setup :*
 
   > Before using this configuration, please confirm in advance that your `Azure OpenAI API key` supports `embedded models`.

--- a/docs/installation_and_configuration.rst
+++ b/docs/installation_and_configuration.rst
@@ -32,6 +32,17 @@ Option 1: Unified API base for both models
       OPENAI_API_BASE=<your_unified_api_base>
       OPENAI_API_KEY=<replace_with_your_openai_api_key>
 
+Configuration Example: Tuning Engines Setup
+-------------------------------------------
+
+   .. code-block:: Properties
+
+      # Route chat and embedding calls through the Tuning Engines OpenAI-compatible endpoint.
+      CHAT_MODEL=openai/<your_chat_model_alias>
+      EMBEDDING_MODEL=openai/<your_embedding_model_alias>
+      OPENAI_API_BASE=https://api.tuningengines.com/v1
+      OPENAI_API_KEY=<replace_with_your_tuning_engines_inference_key>
+
 Option 2: Separate API bases for Chat and Embedding models
 ----------------------------------------------------------
 
@@ -443,4 +454,3 @@ However, this feature is not enabled by default for other scripts. We recommend 
           export $(grep -v '^#' .env | xargs)
     
     - If you want to change the default environment variables, you can refer to the above configuration and edith the `.env` file.
-


### PR DESCRIPTION
## Description

Adds a documentation-only example for routing RD-Agent chat and embedding calls through Tuning Engines using the existing LiteLLM/OpenAI-compatible configuration.

## Motivation and Context

RD-Agent already documents unified and separate LiteLLM API bases. This adds a concrete OpenAI-compatible gateway example so users can configure Tuning Engines with `OPENAI_API_BASE` and a gateway-issued inference key.

## How Has This Been Tested?

- [ ] If you are adding a new feature, test on your own test scripts.

Docs-only change; no runtime tests were run.

## Screenshots of Test Results (if appropriate):

N/A

## Types of changes

- [ ] Fix bugs
- [ ] Add new feature
- [x] Update documentation


<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1419.org.readthedocs.build/en/1419/

<!-- readthedocs-preview RDAgent end -->