### PR TITLE
fix(qlib/factor loader): read factor JSON as UTF-8

### DIFF
--- a/rdagent/scenarios/qlib/factor_experiment_loader/json_loader.py
+++ b/rdagent/scenarios/qlib/factor_experiment_loader/json_loader.py
@@ -30,7 +30,7 @@ class FactorExperimentLoaderFromDict(FactorExperimentLoader):
 
 class FactorExperimentLoaderFromJsonFile(FactorExperimentLoader):
     def load(self, json_file_path: Path) -> list:
-        with open(json_file_path, "r") as file:
+        with open(json_file_path, "r", encoding="utf-8") as file:
             factor_dict = json.load(file)
         return FactorExperimentLoaderFromDict().load(factor_dict)
 
@@ -45,7 +45,7 @@ class FactorExperimentLoaderFromJsonString(FactorExperimentLoader):
 # class FactorTestCaseLoaderFromJsonFile(Loader[TestCases]):
 class FactorTestCaseLoaderFromJsonFile:
     def load(self, json_file_path: Path) -> TestCases:
-        with open(json_file_path, "r") as file:
+        with open(json_file_path, "r", encoding="utf-8") as file:
             factor_dict = json.load(file)
         test_cases = TestCases()
         for factor_name, factor_data in factor_dict.items():


### PR DESCRIPTION
## Description

`FactorExperimentLoaderFromJsonFile` and `FactorTestCaseLoaderFromJsonFile` (`rdagent/scenarios/qlib/factor_experiment_loader/json_loader.py`) opened the factor / testcase JSON files with no explicit `encoding`, so the read fell back to the platform default — `cp1252` / `gbk` on Windows.

Factor definition JSON routinely carries non-ASCII content (localized factor names and descriptions), and JSON is UTF-8 by default per [RFC 8259 §8.1](https://www.rfc-editor.org/rfc/rfc8259#section-8.1). On a non-UTF-8 locale the load therefore fails with `UnicodeDecodeError`, the same class of failure already fixed for template loading.

## Change

Pin `encoding="utf-8"` on both `open()` calls so the read matches the JSON contract regardless of platform locale. No behavior change on UTF-8 locales.

## Testing

`json.load` of a factor JSON containing non-ASCII names/descriptions now succeeds independent of `locale.getpreferredencoding()`. Existing ASCII factor files are unaffected.

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1421.org.readthedocs.build/en/1421/

<!-- readthedocs-preview RDAgent end -->