### PR TITLE
fix(loader): close model task JSON file and read it as UTF-8

### DIFF
--- a/rdagent/components/loader/task_loader.py
+++ b/rdagent/components/loader/task_loader.py
@@ -47,7 +47,8 @@ class ModelTaskLoaderJson(ModelTaskLoader):
 
     def load(self, *argT, **kwargs) -> Sequence[ModelTask]:
         # json is supposed to be in the format of {model_name: dict{model_data}}
-        model_dict = json.load(open(self.json_uri, "r"))
+        with open(self.json_uri, "r", encoding="utf-8") as f:
+            model_dict = json.load(f)
         # FIXME: the model in the json file is not right due to extraction error
         #       We should fix them case by case in the future
         #


### PR DESCRIPTION
## Description

`ModelTaskLoaderJson.load` (`rdagent/components/loader/task_loader.py`) read the model JSON via `json.load(open(self.json_uri, "r"))`. That has two problems:

1. The file handle is never closed (leaked until GC).
2. No explicit `encoding`, so the read falls back to the platform default — `cp1252` / `gbk` on Windows.

Model definition JSON can carry non-ASCII content, and JSON is UTF-8 by default per [RFC 8259 §8.1](https://www.rfc-editor.org/rfc/rfc8259#section-8.1), so on a non-UTF-8 locale the load raises `UnicodeDecodeError`.

## Change

Wrap the read in a `with` context manager and pin `encoding="utf-8"`. Closes the handle deterministically and makes the read locale-independent. No behavior change on UTF-8 locales.

## Testing

`json.load` of a model JSON containing non-ASCII content now succeeds independent of `locale.getpreferredencoding()`; the file handle is released on block exit.

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1422.org.readthedocs.build/en/1422/

<!-- readthedocs-preview RDAgent end -->