### PR TITLE
fix: restore DS_RD_SETTING auto-recovery thresholds after merge phase (#1431)

### DIFF
--- a/rdagent/scenarios/data_science/proposal/exp_gen/merge.py
+++ b/rdagent/scenarios/data_science/proposal/exp_gen/merge.py
@@ -1,6 +1,7 @@
 """Merge the version in different traces"""
 
 import json
+from contextlib import contextmanager
 from datetime import timedelta
 from typing import Dict, Tuple
 
@@ -21,6 +22,19 @@ from rdagent.utils.workflow import wait_retry
 from .proposal import (
     HypothesisComponent,  # FIXME: for statistic of other branches after running, remove this later
 )
+
+
+@contextmanager
+def _disable_auto_recovery():
+    prev_t = DS_RD_SETTING.coding_fail_reanalyze_threshold
+    prev_e = DS_RD_SETTING.consecutive_errors
+    DS_RD_SETTING.coding_fail_reanalyze_threshold = 100000
+    DS_RD_SETTING.consecutive_errors = 100000
+    try:
+        yield
+    finally:
+        DS_RD_SETTING.coding_fail_reanalyze_threshold = prev_t
+        DS_RD_SETTING.consecutive_errors = prev_e
 
 
 class MergeExpGen(ExpGen):
@@ -262,14 +276,11 @@ class ExpGen2TraceAndMerge(ExpGen):
             trace.set_current_selection(selection)
             return self.exp_gen.gen(trace)
         else:
-            # disable reset in merging stage
-            DS_RD_SETTING.coding_fail_reanalyze_threshold = 100000
-            DS_RD_SETTING.consecutive_errors = 100000
-
-            if trace.sub_trace_count < 2:
-                return self.exp_gen.gen(trace)
-            else:
-                return self.merge_exp_gen.gen(trace)
+            with _disable_auto_recovery():
+                if trace.sub_trace_count < 2:
+                    return self.exp_gen.gen(trace)
+                else:
+                    return self.merge_exp_gen.gen(trace)
 
 
 class MergeExpGen_MultiTrace(ExpGen):
@@ -392,23 +403,20 @@ class ExpGen2TraceAndMergeV2(ExpGen):
             return self.exp_gen.gen(trace)
 
         else:
-            # disable reset in merging stage
-            DS_RD_SETTING.coding_fail_reanalyze_threshold = 100000
-            DS_RD_SETTING.consecutive_errors = 100000
-
-            leaves: list[int] = trace.get_leaves()
-            if len(leaves) < 2:
-                trace.set_current_selection(selection=(-1,))
-                return self.exp_gen.gen(trace)
-            else:
-                if not self.flag_start_merge:  # root node of the merge trace
-                    self.flag_start_merge = True
-                    trace.set_current_selection(trace.NEW_ROOT)
-                    return self.merge_exp_gen.gen(trace)
-                else:
-                    # return self.merge_exp_gen.gen(trace)
+            with _disable_auto_recovery():
+                leaves: list[int] = trace.get_leaves()
+                if len(leaves) < 2:
                     trace.set_current_selection(selection=(-1,))
-                    return self.exp_gen.gen(trace)  # continue the last trace, to polish the merged solution
+                    return self.exp_gen.gen(trace)
+                else:
+                    if not self.flag_start_merge:  # root node of the merge trace
+                        self.flag_start_merge = True
+                        trace.set_current_selection(trace.NEW_ROOT)
+                        return self.merge_exp_gen.gen(trace)
+                    else:
+                        # return self.merge_exp_gen.gen(trace)
+                        trace.set_current_selection(selection=(-1,))
+                        return self.exp_gen.gen(trace)  # continue the last trace, to polish the merged solution
 
 
 class ExpGen2TraceAndMergeV3(ExpGen):
@@ -428,20 +436,17 @@ class ExpGen2TraceAndMergeV3(ExpGen):
         if timer.remain_time() >= timedelta(hours=DS_RD_SETTING.merge_hours):
             return self.exp_gen.gen(trace)
         else:
-            # disable reset in merging stage
-            DS_RD_SETTING.coding_fail_reanalyze_threshold = 100000
-            DS_RD_SETTING.consecutive_errors = 100000
-
-            leaves: list[int] = trace.get_leaves()
-            if len(leaves) < 2:
-                trace.set_current_selection(selection=(-1,))
-                return self.exp_gen.gen(trace)
-            else:
-                selection = (leaves[0],)
-                if trace.sota_exp_to_submit is not None:
-                    for i in range(1, len(leaves)):
-                        if trace.is_parent(trace.exp2idx(trace.sota_exp_to_submit), leaves[i]):
-                            selection = (leaves[i],)
-                            break
-                trace.set_current_selection(selection)
-                return self.merge_exp_gen.gen(trace)
+            with _disable_auto_recovery():
+                leaves: list[int] = trace.get_leaves()
+                if len(leaves) < 2:
+                    trace.set_current_selection(selection=(-1,))
+                    return self.exp_gen.gen(trace)
+                else:
+                    selection = (leaves[0],)
+                    if trace.sota_exp_to_submit is not None:
+                        for i in range(1, len(leaves)):
+                            if trace.is_parent(trace.exp2idx(trace.sota_exp_to_submit), leaves[i]):
+                                selection = (leaves[i],)
+                                break
+                    trace.set_current_selection(selection)
+                    return self.merge_exp_gen.gen(trace)

--- a/rdagent/scenarios/data_science/proposal/exp_gen/router/__init__.py
+++ b/rdagent/scenarios/data_science/proposal/exp_gen/router/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
@@ -31,6 +32,19 @@ if TYPE_CHECKING:
     from rdagent.scenarios.data_science.experiment.experiment import DSExperiment
     from rdagent.scenarios.data_science.proposal.exp_gen.base import DSTrace, Experiment
     from rdagent.utils.workflow.loop import LoopBase
+
+
+@contextmanager
+def _disable_auto_recovery():
+    prev_t = DS_RD_SETTING.coding_fail_reanalyze_threshold
+    prev_e = DS_RD_SETTING.consecutive_errors
+    DS_RD_SETTING.coding_fail_reanalyze_threshold = 100000
+    DS_RD_SETTING.consecutive_errors = 100000
+    try:
+        yield
+    finally:
+        DS_RD_SETTING.coding_fail_reanalyze_threshold = prev_t
+        DS_RD_SETTING.consecutive_errors = prev_e
 
 
 class ParallelMultiTraceExpGen(ExpGen):
@@ -115,10 +129,9 @@ class ParallelMultiTraceExpGen(ExpGen):
                     and timer.remain_time() < timedelta(hours=DS_RD_SETTING.merge_hours)
                     and len(leaves) >= 2
                 ):
-                    DS_RD_SETTING.coding_fail_reanalyze_threshold = 100000
-                    DS_RD_SETTING.consecutive_errors = 100000
-                    exp = self.merge_exp_gen.gen(trace, plan=ds_plan)
-                    exp_gen_type = type(self.merge_exp_gen).__name__
+                    with _disable_auto_recovery():
+                        exp = self.merge_exp_gen.gen(trace, plan=ds_plan)
+                        exp_gen_type = type(self.merge_exp_gen).__name__
                 else:
                     # If there is a sota experiment in the sub-trace and not in merge time, we use default exp_gen
                     exp = self.exp_gen.gen(trace, plan=ds_plan)


### PR DESCRIPTION
## Summary

Fixes **#1431** by ensuring temporary merge-phase overrides of `DS_RD_SETTING.coding_fail_reanalyze_threshold` and `DS_RD_SETTING.consecutive_errors` are always restored after merge generation completes.

### What changed

* Added a context manager to temporarily disable auto-recovery during merge-phase experiment generation.
* Restored the original `DS_RD_SETTING` values using `try/finally`, ensuring restoration even if an exception occurs.
* Replaced the repeated global setting mutations in all affected merge-phase call sites with the shared helper.

### Why

Previously, merge-phase execution permanently modified the process-wide `DS_RD_SETTING` singleton:

* `coding_fail_reanalyze_threshold`
* `consecutive_errors`

Because these values were never restored, the auto-recovery logic in `DataScienceRDLoop.record()` became effectively disabled for the remainder of the process, causing failed coding iterations to continue retrying indefinitely instead of triggering the intended restart/reanalysis behavior.

This change scopes the override to the duration of merge-phase execution only and restores the original behavior immediately afterward.

### Testing

*  `python -m py_compile` passed for the modified modules.
*  Offline tests passed.
*  Full test suite: **81 passed**, **29 failed**.
*  Import test (`test_import_modules`) passed, including **299 subtests**, confirming the modified modules import correctly.

The **29 failing tests are pre-existing and unrelated to this change** (API keys, Docker, Kaggle authentication, etc.).

### Branch

`fix/merge-phase-auto-recovery-restore`

### Commit

`d211204`

Closes #1431.


<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1433.org.readthedocs.build/en/1433/

<!-- readthedocs-preview RDAgent end -->