### PR TITLE
fix: preserve default Docker extra_volumes in factor/model envs (#1428)

### DIFF
--- a/rdagent/components/coder/factor_coder/config.py
+++ b/rdagent/components/coder/factor_coder/config.py
@@ -31,14 +31,15 @@ class FactorCoSTEERSettings(CoSTEERSettings):
 
 def get_factor_env(
     conf_type: Optional[str] = None,
-    extra_volumes: dict = {},
+    extra_volumes: Optional[dict] = None,
     running_timeout_period: int = 600,
     enable_cache: Optional[bool] = None,
 ) -> Env:
     conf = FactorCoSTEERSettings()
     if hasattr(conf, "python_bin"):
         env = LocalEnv(conf=(CondaConf(conda_env_name=os.environ.get("CONDA_DEFAULT_ENV"))))
-    env.conf.extra_volumes = extra_volumes.copy()
+    if extra_volumes is not None:
+        env.conf.extra_volumes = extra_volumes.copy()
     env.conf.running_timeout_period = running_timeout_period
     if enable_cache is not None:
         env.conf.enable_cache = enable_cache

--- a/rdagent/components/coder/model_coder/conf.py
+++ b/rdagent/components/coder/model_coder/conf.py
@@ -15,7 +15,7 @@ class ModelCoSTEERSettings(CoSTEERSettings):
 
 def get_model_env(
     conf_type: Optional[str] = None,
-    extra_volumes: dict = {},
+    extra_volumes: Optional[dict] = None,
     running_timeout_period: int = 600,
     enable_cache: Optional[bool] = None,
 ) -> Env:
@@ -27,7 +27,8 @@ def get_model_env(
     else:
         raise ValueError(f"Unknown env type: {conf.env_type}")
 
-    env.conf.extra_volumes = extra_volumes.copy()
+    if extra_volumes is not None:
+        env.conf.extra_volumes = extra_volumes.copy()
     env.conf.running_timeout_period = running_timeout_period
     if enable_cache is not None:
         env.conf.enable_cache = enable_cache


### PR DESCRIPTION
## Summary

Fixes **#1428** by preserving the default Docker `extra_volumes` configuration when no explicit volume mappings are provided.

## What changed

* Updated `get_factor_env()` to avoid overwriting `env.conf.extra_volumes` when `extra_volumes` is empty.
* Applied the same fix to `get_model_env()` to keep the behavior consistent across both environment factories.
* Retained the existing `QlibDockerConf` default volume mappings unless the caller explicitly provides custom mappings.

## Why

Both `get_factor_env()` and `get_model_env()` initialized `extra_volumes` with an empty dictionary and unconditionally assigned it to `env.conf.extra_volumes`.

As a result, the default `QlibDockerConf` mount:

* `~/.qlib/` → `/root/.qlib/`

was replaced with an empty dictionary. Consequently, `QTDockerEnv.prepare()` attempted to access the first configured volume and raised a `StopIteration`, preventing Docker-based factor/model workflows from starting.

With this change, the default configuration is preserved unless the caller explicitly supplies custom volume mappings.

## Testing

*  Confirmed the reported bug and reproduced the failure.
*  Verified that the previous implementation raises `StopIteration` while the updated implementation preserves the default configuration.
*  `python -m py_compile` passed for all modified files.
*  Import test passed (**299 subtests**), confirming the modified modules load successfully.

## Files Changed

* `rdagent/components/coder/factor_coder/config.py`
* `rdagent/components/coder/model_coder/config.py`

## Branch

`fix/extra-volumes-overwrite-bug`

## Commit

`477b6bc`

Closes #1428.


<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1435.org.readthedocs.build/en/1435/

<!-- readthedocs-preview RDAgent end -->