### PR TITLE
Agent-driven quant R&D loop: run_qlib + guardrail (ADR 0002)

### DIFF
--- a/agent_loop/__init__.py
+++ b/agent_loop/__init__.py
@@ -1,0 +1,11 @@
+"""
+agent_loop — deterministic, LLM-free tooling for the agent-driven quant R&D loop.
+
+This package is intentionally kept OUTSIDE the vendored `rdagent/` tree so that
+periodic upstream merges of microsoft/RD-Agent stay cheap (see ADR 0002). It wraps
+RD-Agent's execution machinery (Dockerized qlib backtests, the trace ledger, and a
+statistical guardrail) as tools that *this session's agent* drives directly — the
+agent is the brain (propose / code / judge); these tools are the hands.
+
+Nothing in here calls an LLM. No ANTHROPIC_API_KEY / LiteLLM is required.
+"""

--- a/agent_loop/guardrail.py
+++ b/agent_loop/guardrail.py
@@ -1,0 +1,249 @@
+"""
+rdagent-guardrail — the deterministic promote/reject gate (ADR 0002 Phase B; ADR 0001 §7 v0).
+
+This is the scientific crux of the agent-driven loop: it replaces RD-Agent's LLM-judge summarizer
+(which lets an LLM eyeball test-segment metrics — textbook selection-on-the-test-set) with a
+*deterministic* rule. There is NO LLM here.
+
+A candidate is promoted to SOTA only if ALL gates pass:
+
+  1. holdout_ok      — beats the current SOTA on a LOCKED holdout segment the loop never selects on
+                       (or clears an absolute floor if there is no incumbent).
+  2. dsr_ok          — its Deflated Sharpe Ratio (Bailey & Lopez de Prado, 2014) exceeds a threshold.
+                       DSR haircuts the Sharpe for (a) the number of trials tried so far and (b) the
+                       non-normality (skew/kurtosis) of returns. As trial count grows, the bar rises,
+                       so marginal "winners" found by searching get rejected.
+  3. net_positive    — its net-of-cost information ratio is positive (reject pure gross winners).
+  4. beats_sota_net  — its net-of-cost IR beats the incumbent's by a margin.
+
+Inputs are the JSON emitted by `agent_loop.run_qlib` (which records the workspace path, so the raw
+daily-return series in `<workspace>/ret.pkl` is available for honest T / skew / kurtosis).
+
+Trace JSON schema (shared with the Phase C `trace` tool) — all fields optional except `trials`:
+    {"trials": [{"loop": int, "action": str, "decision": bool,
+                 "sr_period": float, "holdout_metrics": {metric: value}, ...}],
+     "sota_loop": int | null}
+N (number of trials for the DSR haircut) = len(trials) + 1 (this candidate).
+"""
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import fire
+import numpy as np
+import pandas as pd
+from scipy.stats import norm
+
+EULER_GAMMA = 0.5772156649015329
+TRADING_DAYS = 252
+
+
+# --------------------------------------------------------------------------- stats
+def daily_excess_returns(workspace: str | Path, with_cost: bool = True) -> pd.Series:
+    """Daily excess return series from a run's ret.pkl (qlib report_normal_1day).
+
+    excess_with_cost = return - bench - cost ;  excess_without_cost = return - bench.
+    """
+    ret_path = Path(workspace) / "ret.pkl"
+    if not ret_path.exists():
+        raise FileNotFoundError(f"ret.pkl not found in workspace: {ret_path}")
+    df = pd.read_pickle(ret_path)
+    exc = df["return"] - df["bench"]
+    if with_cost:
+        exc = exc - df["cost"]
+    return exc.dropna()
+
+
+def sharpe_stats(returns: pd.Series) -> dict[str, float]:
+    """Per-period Sharpe plus the higher moments the DSR standard error needs."""
+    r = np.asarray(returns, dtype=float)
+    T = int(r.size)
+    mean, std = float(r.mean()), float(r.std(ddof=1))
+    sr = mean / std if std > 0 else 0.0
+    return {
+        "T": T,
+        "mean": mean,
+        "std": std,
+        "sr_period": sr,
+        "sr_ann": sr * math.sqrt(TRADING_DAYS),
+        "skew": float(pd.Series(r).skew()),
+        "kurt": float(pd.Series(r).kurt() + 3.0),  # pandas kurt is excess; DSR wants raw (normal=3)
+    }
+
+
+def probabilistic_sharpe_ratio(sr: float, sr_benchmark: float, T: int, skew: float, kurt: float) -> float:
+    """PSR: P(true per-period SR > sr_benchmark), using the Mertens standard error of Sharpe."""
+    denom = 1.0 - skew * sr + ((kurt - 1.0) / 4.0) * sr * sr
+    denom = max(denom, 1e-12)
+    z = (sr - sr_benchmark) * math.sqrt(max(T - 1, 1)) / math.sqrt(denom)
+    return float(norm.cdf(z))
+
+
+def expected_max_sharpe(n_trials: int, var_sr_period: float) -> float:
+    """Expected maximum per-period Sharpe under the null of `n_trials` noise strategies."""
+    if n_trials <= 1 or var_sr_period <= 0:
+        return 0.0
+    sigma = math.sqrt(var_sr_period)
+    a = norm.ppf(1.0 - 1.0 / n_trials)
+    b = norm.ppf(1.0 - 1.0 / (n_trials * math.e))
+    return sigma * ((1.0 - EULER_GAMMA) * a + EULER_GAMMA * b)
+
+
+def deflated_sharpe_ratio(
+    stats: dict[str, float], n_trials: int, var_sr_period: float | None
+) -> dict[str, Any]:
+    """DSR = PSR against the expected-max-Sharpe benchmark implied by multiple testing."""
+    sr, T, skew, kurt = stats["sr_period"], stats["T"], stats["skew"], stats["kurt"]
+    if var_sr_period is None:
+        # No trial-dispersion estimate yet: assume trials are null noise, Var(SR)~1/T.
+        var_sr_period = 1.0 / max(T - 1, 1)
+        var_source = "default_1/T"
+    else:
+        var_source = "trace_trial_variance"
+    sr0 = expected_max_sharpe(n_trials, var_sr_period)
+    dsr = probabilistic_sharpe_ratio(sr, sr0, T, skew, kurt)
+    return {
+        "value": dsr,
+        "n_trials": n_trials,
+        "benchmark_sr_period": sr0,
+        "benchmark_sr_ann": sr0 * math.sqrt(TRADING_DAYS),
+        "var_sr_period": var_sr_period,
+        "var_sr_source": var_source,
+    }
+
+
+# --------------------------------------------------------------------------- helpers
+def _load(obj: str | dict | None) -> dict | None:
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj
+    return json.loads(Path(obj).read_text())
+
+
+def _ir_with_cost(res: dict) -> float:
+    return float(res["metrics"]["1day.excess_return_with_cost.information_ratio"])
+
+
+def _sota_from_trace(trace: dict | None) -> dict | None:
+    if not trace or not trace.get("trials"):
+        return None
+    accepted = [t for t in trace["trials"] if t.get("decision")]
+    if not accepted:
+        return None
+    sota_loop = trace.get("sota_loop")
+    if sota_loop is not None:
+        for t in accepted:
+            if t.get("loop") == sota_loop:
+                return t
+    return accepted[-1]
+
+
+# --------------------------------------------------------------------------- gate
+def evaluate(
+    candidate: str,
+    holdout: str | None = None,
+    trace: str | None = None,
+    sota: str | None = None,
+    dsr_threshold: float = 0.95,
+    cost_margin: float = 0.0,
+    holdout_metric: str = "Rank IC",
+    min_holdout: float = 0.0,
+    out: str | None = None,
+) -> dict[str, Any]:
+    """Decide whether `candidate` should replace the current SOTA. Returns a decision dict.
+
+    candidate/holdout/sota: paths to run_qlib JSON (selection segment, locked-holdout segment, and
+    the incumbent's selection JSON, respectively). trace: path to the trace ledger JSON.
+    """
+    cand = _load(candidate)
+    hold = _load(holdout)
+    trace_d = _load(trace)
+    sota_sel = _load(sota) or _sota_from_trace(trace_d)
+
+    stats = sharpe_stats(daily_excess_returns(cand["workspace"], with_cost=True))
+    n_trials = (len(trace_d["trials"]) + 1) if (trace_d and trace_d.get("trials")) else 1
+
+    var_sr = None
+    if trace_d and trace_d.get("trials"):
+        srs = [t["sr_period"] for t in trace_d["trials"] if t.get("sr_period") is not None]
+        if len(srs) >= 2:
+            var_sr = float(np.var(srs, ddof=1))
+    dsr = deflated_sharpe_ratio(stats, n_trials, var_sr)
+
+    reasons: list[str] = []
+
+    # gate: DSR
+    dsr_ok = dsr["value"] >= dsr_threshold
+    reasons.append(
+        f"DSR={dsr['value']:.4f} {'>=' if dsr_ok else '<'} {dsr_threshold} "
+        f"(N={n_trials}, benchmark SR_ann={dsr['benchmark_sr_ann']:.3f}, var_src={dsr['var_sr_source']})"
+    )
+
+    # gate: net-of-cost positive
+    cand_ir_net = _ir_with_cost(cand)
+    net_positive = cand_ir_net > 0.0
+    reasons.append(f"net IR(with cost)={cand_ir_net:+.4f} {'> 0' if net_positive else '<= 0 (reject gross-only)'}")
+
+    # gate: beats SOTA net-of-cost
+    sota_ir_net = _ir_with_cost(sota_sel) if sota_sel and "metrics" in sota_sel else 0.0
+    beats_sota_net = cand_ir_net > sota_ir_net + cost_margin
+    reasons.append(
+        f"net IR beats SOTA: {cand_ir_net:+.4f} vs {sota_ir_net:+.4f}+{cost_margin} -> {beats_sota_net}"
+        + ("" if sota_sel else " (no incumbent -> bar is 0)")
+    )
+
+    # gate: locked holdout
+    if hold is None:
+        holdout_ok = False
+        reasons.append("HOLDOUT MISSING -> cannot promote (a locked-holdout run is required)")
+    else:
+        cand_h = float(hold["metrics"].get(holdout_metric))
+        sota_h = None
+        if sota_sel and sota_sel.get("holdout_metrics"):
+            sota_h = sota_sel["holdout_metrics"].get(holdout_metric)
+        bar = sota_h if sota_h is not None else min_holdout
+        holdout_ok = cand_h > bar
+        reasons.append(
+            f"holdout {holdout_metric}={cand_h:+.4f} {'>' if holdout_ok else '<='} "
+            f"{bar:+.4f} ({'SOTA holdout' if sota_h is not None else 'floor'})"
+        )
+
+    decision = bool(holdout_ok and dsr_ok and net_positive and beats_sota_net)
+
+    result = {
+        "decision": decision,
+        "candidate_workspace": cand["workspace"],
+        "n_trials": n_trials,
+        "candidate": {
+            "sr_period": stats["sr_period"],
+            "sr_ann": stats["sr_ann"],
+            "T": stats["T"],
+            "skew": stats["skew"],
+            "kurt": stats["kurt"],
+            "ir_with_cost": cand_ir_net,
+        },
+        "dsr": dsr,
+        "gates": {
+            "holdout_ok": holdout_ok,
+            "dsr_ok": dsr_ok,
+            "net_positive": net_positive,
+            "beats_sota_net": beats_sota_net,
+        },
+        "reasons": reasons,
+    }
+
+    print(f"\n==== guardrail: {'PROMOTE' if decision else 'REJECT'} ====")
+    for r in reasons:
+        print(" -", r)
+    if out is not None:
+        Path(out).write_text(json.dumps(result, indent=2))
+        print(f"\n[guardrail] wrote {out}")
+    return result
+
+
+if __name__ == "__main__":
+    fire.Fire(evaluate)

--- a/agent_loop/run_qlib.py
+++ b/agent_loop/run_qlib.py
@@ -1,0 +1,163 @@
+"""
+rdagent-run-qlib — run a qlib backtest as a deterministic, LLM-free tool.
+
+This is the "run" hand of the agent-driven loop (ADR 0002). The agent proposes a
+hypothesis and writes factor/model code; this tool executes it against qlib inside
+the vendored Docker image and returns the metric Series (`exp.result`). No LLM, no
+.env, no ANTHROPIC_API_KEY.
+
+It wraps `QlibFBWorkspace.execute()` (which is already LLM-free) and bakes in the
+two environment fixes needed on this machine, discovered during slice-1 bring-up:
+  1. Force env_type=docker (the default is conda, which would auto-build a heavy
+     `rdagent4qlib` env; the `local_qlib:latest` image is already provisioned).
+  2. Pass MLFLOW_ALLOW_FILE_STORE=true into the container (its newer mlflow refuses
+     the file-store backend otherwise).
+
+Examples
+--------
+Baseline (Alpha20 features, LGBM), short segment:
+    python -m agent_loop.run_qlib --conf conf_baseline.yaml \
+        --train_start 2015-01-01 --train_end 2016-12-31 \
+        --valid_start 2017-01-01 --valid_end 2017-12-31 \
+        --test_start 2018-01-01 --test_end 2018-12-31 --out /tmp/res.json
+
+Custom factor(s): drop a `combined_factors_df.parquet` (MultiIndex [datetime,
+instrument] rows; columns under a top-level "feature" level) and run:
+    python -m agent_loop.run_qlib --conf conf_combined_factors.yaml \
+        --factors /path/to/combined_factors_df.parquet --out /tmp/res.json
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+import fire
+
+
+def _rdagent_root() -> Path:
+    # rdagent is a namespace package (__file__ is None); resolve via __path__.
+    import rdagent
+
+    return Path(list(rdagent.__path__)[0])
+
+
+def _template_dir(template: str) -> Path:
+    root = _rdagent_root() / "scenarios" / "qlib" / "experiment"
+    mapping = {
+        "factor": root / "factor_template",
+        "model": root / "model_template",
+    }
+    if template not in mapping:
+        raise ValueError(f"template must be one of {list(mapping)}, got {template!r}")
+    d = mapping[template]
+    if not d.is_dir():
+        raise FileNotFoundError(f"template folder not found: {d}")
+    return d
+
+
+def _load_features(features: str | None) -> dict[str, str]:
+    if features is None:
+        from rdagent.utils.qlib import ALPHA20
+
+        return dict(ALPHA20)
+    p = Path(features)
+    data = json.loads(p.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"{p} must be a JSON object of name -> expression")
+    return data
+
+
+def run(
+    conf: str = "conf_baseline.yaml",
+    template: str = "factor",
+    factors: str | None = None,
+    features: str | None = None,
+    train_start: str | None = None,
+    train_end: str | None = None,
+    valid_start: str | None = None,
+    valid_end: str | None = None,
+    test_start: str | None = None,
+    test_end: str | None = None,
+    env: str = "docker",
+    gpu: bool = False,
+    timeout: int = 3600,
+    out: str | None = None,
+) -> dict[str, Any]:
+    """Run a qlib backtest and return {metric_name: value}.
+
+    Parameters mirror the qlib template segments. Unset date args fall back to the
+    template defaults (train 2008-2014, valid 2015-2016, test 2017+).
+    """
+    # --- force the provisioned execution path (must be set before QTDockerEnv build)
+    os.environ["QLIB_DOCKER_ENABLE_GPU"] = str(bool(gpu))
+    os.environ["QLIB_DOCKER_RUNNING_TIMEOUT_PERIOD"] = str(int(timeout))
+
+    from rdagent.components.coder.model_coder.conf import MODEL_COSTEER_SETTINGS
+    from rdagent.scenarios.qlib.experiment.workspace import QlibFBWorkspace
+
+    MODEL_COSTEER_SETTINGS.env_type = env  # execute() reads this at call time
+
+    template_dir = _template_dir(template)
+    conf_path = template_dir / conf
+    if not conf_path.exists():
+        available = sorted(p.name for p in template_dir.glob("conf*.yaml"))
+        raise FileNotFoundError(f"{conf!r} not in {template_dir}. Available: {available}")
+
+    feats = _load_features(features)
+    run_env = {
+        "PYTHONPATH": "./",
+        # Container ships a newer mlflow that refuses the file store unless opted in.
+        "MLFLOW_ALLOW_FILE_STORE": "true",
+        "feature_names": str(list(feats.keys())),
+        "feature_expressions": str(list(feats.values())),
+    }
+    for k, v in {
+        "train_start": train_start,
+        "train_end": train_end,
+        "valid_start": valid_start,
+        "valid_end": valid_end,
+        "test_start": test_start,
+        "test_end": test_end,
+    }.items():
+        if v is not None:
+            run_env[k] = v
+
+    ws = QlibFBWorkspace(template_folder_path=template_dir)
+    if factors is not None:
+        src = Path(factors)
+        if not src.exists():
+            raise FileNotFoundError(f"--factors parquet not found: {src}")
+        shutil.copy(src, ws.workspace_path / "combined_factors_df.parquet")
+
+    print(f"[run-qlib] env={env} gpu={gpu} conf={conf} workspace={ws.workspace_path}")
+    result, stdout = ws.execute(qlib_config_name=conf, run_env=run_env)
+
+    if result is None:
+        tail = (stdout or "")[-2000:]
+        raise RuntimeError(f"qlib run produced no result. stdout tail:\n{tail}")
+
+    metrics = {str(k): float(v) for k, v in result.items()}
+    print("\n==== metrics ====")
+    for k in sorted(metrics):
+        print(f"{k:52s} {metrics[k]:+.6f}")
+
+    payload = {
+        "workspace": str(ws.workspace_path),
+        "conf": conf,
+        "segments": {
+            k: run_env.get(k)
+            for k in ("train_start", "train_end", "valid_start", "valid_end", "test_start", "test_end")
+        },
+        "metrics": metrics,
+    }
+    if out is not None:
+        Path(out).write_text(json.dumps(payload, indent=2))
+        print(f"\n[run-qlib] wrote {out}")
+    return payload
+
+
+if __name__ == "__main__":
+    fire.Fire(run)

--- a/agent_loop/tests/test_guardrail.py
+++ b/agent_loop/tests/test_guardrail.py
@@ -1,0 +1,111 @@
+"""
+Acceptance tests for the guardrail (ADR 0002 Phase B / ADR 0001 §7).
+
+Self-contained: fabricates a ret.pkl with a controlled daily excess-return series (return-bench-cost)
+so we can dial an exact Sharpe and trial count and assert the promote/reject decision. No Docker, no
+LLM. Run with `pytest agent_loop/tests/test_guardrail.py` or directly as a script.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from agent_loop import guardrail
+
+TRADING_DAYS = 252
+
+
+def _make_run(root: Path, name: str, sr_ann: float, T: int = 243, holdout_rank_ic: float | None = None) -> str:
+    """Workspace with a ret.pkl at an exact per-day Sharpe; returns the run-JSON path."""
+    d = root / name
+    d.mkdir(parents=True, exist_ok=True)
+    rng = np.random.default_rng(0)
+    z = rng.standard_normal(T)
+    z = (z - z.mean()) / z.std(ddof=1)  # standardize -> exact target Sharpe
+    sigma = 0.01
+    ret = (sr_ann / np.sqrt(TRADING_DAYS)) * sigma + sigma * z
+    pd.DataFrame(
+        {"return": ret, "bench": np.zeros(T), "cost": np.zeros(T)},
+        index=pd.date_range("2019-01-01", periods=T, freq="B"),
+    ).to_pickle(d / "ret.pkl")
+    metrics = {"1day.excess_return_with_cost.information_ratio": sr_ann}
+    if holdout_rank_ic is not None:
+        metrics["Rank IC"] = holdout_rank_ic
+    p = root / f"{name}.json"
+    p.write_text(json.dumps({"workspace": str(d), "conf": "synthetic", "metrics": metrics}))
+    return str(p)
+
+
+def _make_trace(root: Path, n_noise: int, sr_std: float, accepted_holdout_rank_ic: float | None = None) -> str:
+    rng = np.random.default_rng(1)
+    trials = [
+        {"loop": i, "action": "factor", "decision": False, "sr_period": float(rng.normal(0, sr_std))}
+        for i in range(n_noise)
+    ]
+    trace: dict = {"trials": trials, "sota_loop": None}
+    if accepted_holdout_rank_ic is not None:
+        trials.append(
+            {"loop": n_noise, "action": "factor", "decision": True, "sr_period": 0.05,
+             "holdout_metrics": {"Rank IC": accepted_holdout_rank_ic}}
+        )
+        trace["sota_loop"] = n_noise
+    p = root / f"trace_{n_noise}.json"
+    p.write_text(json.dumps(trace))
+    return str(p)
+
+
+def test_overfit_factor_rejected_by_holdout(tmp_path: Path):
+    """High selection Sharpe but poor out-of-sample holdout -> rejected on the holdout gate alone."""
+    cand = _make_run(tmp_path, "overfit_cand", sr_ann=2.2)
+    hold = _make_run(tmp_path, "overfit_hold", sr_ann=0.0, holdout_rank_ic=0.004)
+    trace = _make_trace(tmp_path, n_noise=2, sr_std=0.02, accepted_holdout_rank_ic=0.030)
+    res = guardrail.evaluate(candidate=cand, holdout=hold, trace=trace)
+    assert res["decision"] is False
+    assert res["gates"]["dsr_ok"] and res["gates"]["net_positive"]  # other gates pass
+    assert res["gates"]["holdout_ok"] is False  # only holdout fails
+
+
+def test_clean_winner_promoted_at_low_n(tmp_path: Path):
+    cand = _make_run(tmp_path, "win_cand", sr_ann=2.2)
+    hold = _make_run(tmp_path, "win_hold", sr_ann=0.0, holdout_rank_ic=0.04)
+    res = guardrail.evaluate(candidate=cand, holdout=hold, min_holdout=0.0)
+    assert res["decision"] is True
+
+
+def test_dsr_haircut_rejects_after_many_trials(tmp_path: Path):
+    """The SAME Sharpe-2.2 candidate is promoted at N=1 but rejected once 200 trials were tried."""
+    cand = _make_run(tmp_path, "cand", sr_ann=2.2)
+    hold = _make_run(tmp_path, "hold", sr_ann=0.0, holdout_rank_ic=0.04)
+    low = guardrail.evaluate(candidate=cand, holdout=hold, min_holdout=0.0)
+    trace = _make_trace(tmp_path, n_noise=200, sr_std=0.064)
+    high = guardrail.evaluate(candidate=cand, holdout=hold, trace=trace, min_holdout=0.0)
+    assert low["decision"] is True
+    assert high["decision"] is False
+    assert high["gates"]["dsr_ok"] is False
+    assert low["dsr"]["value"] > 0.95 > high["dsr"]["value"]
+
+
+def test_missing_holdout_cannot_promote(tmp_path: Path):
+    cand = _make_run(tmp_path, "cand", sr_ann=2.2)
+    res = guardrail.evaluate(candidate=cand)  # no holdout
+    assert res["decision"] is False
+    assert res["gates"]["holdout_ok"] is False
+
+
+if __name__ == "__main__":
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        for i, fn in enumerate(
+            [test_overfit_factor_rejected_by_holdout, test_clean_winner_promoted_at_low_n,
+             test_dsr_haircut_rejects_after_many_trials, test_missing_holdout_cannot_promote]
+        ):
+            sub = root / f"t{i}"
+            sub.mkdir()
+            fn(sub)
+            print(f"[PASS] {fn.__name__}")
+    print("ALL GUARDRAIL TESTS PASSED")

--- a/docs/proposals/0001-autonomous-quant-rd-loop.md
+++ b/docs/proposals/0001-autonomous-quant-rd-loop.md
@@ -1,0 +1,334 @@
+# ADR 0001 — Fork RD-Agent as the engine for an Autonomous Quant R&D Loop
+
+- **Status:** Proposed
+- **Date:** 2026-07-06
+- **Deciders:** repo owner (fork of `microsoft/RD-Agent`)
+- **Supersedes:** n/a
+- **Context source:** analysis of `microsoft/RD-Agent` @ HEAD (commit dated 2026-05-06, MIT license) and `microsoft/qlib`.
+
+> This document is both a **decision record** and a **cold-start handoff brief**. A fresh
+> Claude Code session opened in the fork should be able to read this top-to-bottom and
+> continue the work without re-deriving anything. All file paths below are relative to the
+> RD-Agent repo root unless noted.
+
+---
+
+## 1. TL;DR decision
+
+**Fork/extend `microsoft/RD-Agent`; do NOT rebuild the R&D loop from scratch.**
+
+RD-Agent already implements the entire loop we want (propose → code → run qlib → evaluate →
+record), Dockerized qlib execution, a DAG research ledger, HITL hooks, checkpoint/resume, and
+factor+model joint optimization — ~65K LOC, MIT-licensed, actively maintained. Every component
+is swappable via a dotted-class-path config (`import_class(PROP_SETTING.*)`).
+
+Our differentiation goes into **three pluggable slots**, not a rewrite:
+
+1. **Statistical eval gate** — replace the LLM-judge `summarizer` with an overfitting-aware
+   feedback module (locked out-of-sample holdout + trial-count-aware Deflated Sharpe). **This is
+   the highest-ROI change and the first deliverable.**
+2. **Curated qlib knowledge substrate** — feed proposals a retrievable "capability wiki"
+   (operators, handlers, model cards, metric semantics), not just prompt-template scenario text.
+3. **Claude backend + optional skill/MCP surface** — point the LiteLLM backend at Claude.
+
+Build from scratch **only** if the research goal is the loop/methodology itself. If
+qlib-driven autonomous alpha research is the goal and the loop is a means: **fork.**
+
+---
+
+## 2. For the next session — start here
+
+**Goal of the project:** an autonomous quant R&D loop that treats qlib as an experiment-execution
+engine and iteratively searches for alpha (factors + models), with *scientifically honest*
+evaluation.
+
+**First milestone (do this before anything else):**
+1. Reproduce the RD-Agent quant baseline end-to-end on this machine so we have a known-good loop.
+2. Point the LLM backend at Claude (LiteLLM).
+3. Land **one** change: swap the factor/model `summarizer` for a guardrail-aware feedback module
+   (§7). This converts a p-hacking-prone loop into something defensible and validates the fork
+   approach in days.
+
+**Environment quick facts (verified):**
+- Python 3.10, `conda create -n rdagent python=3.10` then `pip install -e .` in the fork.
+- **qlib runs inside Docker** (`rdagent/utils/env.py` — `DockerEnv`; there is also a `LocalEnv`).
+  Docker must be available. First run pulls an image.
+- LLM backend is **LiteLLM** (multi-provider). Config via `.env` (see §8).
+- Run the joint factor+model loop: `rdagent fin_quant`  (factor-only: `rdagent fin_factor`,
+  model-only: `rdagent fin_model`, factor-from-report: `rdagent fin_factor_report`).
+- Direct/dev invocation: `python rdagent/app/qlib_rd_loop/quant.py`.
+- Resume a session: `rdagent fin_quant --path <LOG_PATH>/__session__/<i>/<step> --step_n 1`.
+- Health check: `rdagent health_check`.
+
+**Read these files first (in order):**
+1. `rdagent/components/workflow/rd_loop.py` — the generic loop (`RDLoop`).
+2. `rdagent/app/qlib_rd_loop/quant.py` — the quant (factor+model) loop (`QuantRDLoop`).
+3. `rdagent/app/qlib_rd_loop/conf.py` — the pluggable config (`QuantBasePropSetting`).
+4. `rdagent/scenarios/qlib/developer/feedback.py` — the current evaluation (what we replace).
+5. `rdagent/core/proposal.py` — the interfaces (`Experiment2Feedback`, `Trace`, `HypothesisFeedback`).
+
+---
+
+## 3. Background: the vision, formalized
+
+The unit of work is a **Hypothesis** that formalizes to a qlib experiment:
+
+```
+h = (rationale, factor_exprs, model_spec, dataset_spec, eval_plan)
+```
+
+The **loop** (and how it already maps onto RD-Agent's `QuantRDLoop`):
+
+| R&D stage        | Our name           | RD-Agent method (`quant.py`) | What happens                                             |
+|------------------|--------------------|------------------------------|---------------------------------------------------------|
+| Ideate+Formalize | propose            | `direct_exp_gen`             | `hypothesis_gen.gen()` → `hypothesis2experiment.convert()` |
+| Implement        | code               | `coding`                     | LLM writes factor/model code (`factor_coder`/`model_coder`) |
+| Execute          | run                | `running`                    | qlib runs in Docker; code injected into YAML templates   |
+| Evaluate+Reflect | feedback           | `feedback`                   | `summarizer.generate_feedback()` → `HypothesisFeedback`  |
+| Memorize         | record             | `record`                     | `trace.sync_dag_parent_and_hist()` — DAG ledger          |
+
+The agent optimizes an objective (OOS Rank ICIR / portfolio IR) over the search space
+(factors × models × datasets) **subject to guardrails**. "Brainstorming alpha ideas itself" is
+just the Ideate stage running unconditioned instead of conditioned on a user direction.
+
+---
+
+## 4. Verified findings about RD-Agent
+
+**Layering (LOC):** `core/` ~2.0K (abstractions), `components/` ~12.5K (reusable building blocks:
+coder, runner, proposal, workflow, knowledge_management, loader, benchmark), `scenarios/` ~30K
+(qlib, data_science, kaggle, rl, general_model, finetune), `app/` ~6.9K (entry points),
+`oai/` ~1.9K (LLM backend), `utils/` ~3.9K (incl. Docker env + qlib helpers). Total ~65K.
+
+**Fully pluggable.** `QuantBasePropSetting` (`app/qlib_rd_loop/conf.py`, env prefix `QLIB_QUANT_`)
+declares every component as a dotted class path resolved by `import_class(...)`. Overridable by
+env var. Slots: `quant_hypothesis_gen`, `factor_hypothesis2experiment`, `model_hypothesis2experiment`,
+`factor_coder`, `model_coder`, `factor_runner`, `model_runner`, `factor_summarizer`,
+`model_summarizer`, plus `action_selection ∈ {bandit, llm, random}` and the train/valid/test dates.
+
+**Already built (do not rebuild):** Dockerized qlib execution with retries/volume-mounts
+(`utils/env.py`); DAG research ledger (`Trace` in `core/proposal.py`, `trace.hist` is a list of
+`(Experiment, feedback)`); HITL via multiprocessing queues (`_interact_hypo`, `_interact_feedback`);
+checkpoint/resume (`RDLoop.load`, `--step_n/--loop_n/--all_duration`); parallel loops
+(`get_max_parallel`); factor+model **joint** optimization with bandit action selection; a
+knowledge base with vector store + knowledge graph (`components/knowledge_management/vector_base.py`,
+`graph.py`) used for RAG over past coding attempts; LiteLLM multi-provider backend (`rdagent/oai/`).
+
+**Execution mechanics.** Factor/model code the LLM writes is dropped into qlib workflow YAML
+templates (`scenarios/qlib/experiment/factor_template/conf_*.yaml`,
+`.../model_template/`) and run via qlib inside the container. `exp.result` is a pandas object
+indexed by metric name.
+
+---
+
+## 5. The two gaps = our differentiation
+
+### Gap 1 (critical): no statistical overfitting guardrail
+`scenarios/qlib/developer/feedback.py` decides "is this better than the best-so-far" by having an
+**LLM compare metrics**:
+
+```python
+IMPORTANT_METRICS = ["IC",
+                     "1day.excess_return_with_cost.annualized_return",
+                     "1day.excess_return_with_cost.max_drawdown"]
+...
+decision = convert2bool(response_json.get("Replace Best Result", "no"))  # LLM judgment
+```
+
+Across hundreds of trials, "SOTA" is selected by an LLM eyeballing **test/backtest-segment**
+metrics. There is **no** Deflated Sharpe, **no** multiple-testing correction, and **no** locked
+out-of-sample holdout the loop is forbidden to select on. This is textbook selection-on-the-test-set
+/ p-hacking exposure. It is the single biggest scientific weakness — and it lives entirely in a
+pluggable component.
+
+### Gap 2: the "wiki" is prompt-templates, not a curated capability substrate
+Proposal context comes from `scenarios/qlib/prompts.yaml` scenario descriptions plus RAG over past
+*experience*. There is no curated, retrievable corpus of qlib's expression operators, handler
+catalog (Alpha158/Alpha360), model cards, or metric semantics — the substrate the vision calls for.
+
+### (Not a gap, a preference) Not Claude-Code-native
+It's a standalone framework (`LoopBase`, `pydantic-settings`, `fire`/`typer`, hard Docker dep,
+prompt-YAML system). Forking means adopting these conventions. Acceptable given the head start.
+
+---
+
+## 6. Decision & alternatives considered
+
+**Decision:** Fork. Vendor RD-Agent's loop + qlib scenario as the engine; add differentiation via
+the three plug-points.
+
+**Alternatives considered:**
+- **Build fresh in a Claude-Code-native stack (skills + MCP + custom loop).** Rejected: rebuilds
+  the hard, non-differentiating 80% (Docker qlib exec, coder, runner, trace, HITL, resume) —
+  months of work, and we'd rediscover the same failure modes (uncompilable factors, env setup).
+  Choose this only if the *loop itself* is the research contribution.
+- **Contribute upstream to RD-Agent instead of forking.** Deferred: guardrails and a curated
+  substrate are opinionated research changes; iterate in a fork first, upstream later if desired.
+- **Use RD-Agent unmodified.** Rejected: the guardrail gap makes results non-defensible for our
+  purposes.
+
+**Consequences:** we inherit RD-Agent's conventions and Docker dependency and track upstream via
+periodic merges; in exchange we get a working loop on day one and confine our work to three modules.
+
+---
+
+## 7. First deliverable — the guardrail feedback module
+
+Replace the LLM-judge summarizer with an **overfitting-aware `Experiment2Feedback`**. Interface
+(verified in `core/proposal.py`):
+
+```python
+class Experiment2Feedback(ABC):
+    def __init__(self, scen: Scenario) -> None: ...
+    @abstractmethod
+    def generate_feedback(self, exp: Experiment, trace: Trace) -> HypothesisFeedback: ...
+
+# HypothesisFeedback fields: observations, hypothesis_evaluation, new_hypothesis, reason, decision(bool)
+# decision == "replace the current SOTA with this experiment"
+# trace.hist : list[(Experiment, feedback)]   → number of trials so far = len(trace.hist)
+# trace.get_sota_hypothesis_and_experiment()  → current best
+# exp.result : pandas object indexed by metric name (see IMPORTANT_METRICS)
+```
+
+**Design (phased):**
+
+- **v0 — trial-count-aware promotion gate (cheapest, do first).** Wrap the existing LLM feedback
+  (keep its qualitative `observations`/`new_hypothesis` — they guide the next proposal well), but
+  **override `decision`** with a statistical rule:
+  - Maintain a **locked holdout** the loop never selects on. Concretely: carve a final segment
+    after `test_end` (e.g. reserve 2019–2020 as OOS, train/select on ≤2018), or extend the data and
+    hold out the last N months. The LLM sees only the selection segment; the gate scores the holdout.
+  - Compute a **Deflated Sharpe Ratio** (Bailey & López de Prado 2014) using `N = len(trace.hist)`
+    (number of trials) and the variance of trial Sharpes accumulated in the trace. Promote only if
+    `DSR > threshold` **and** the holdout metric beats SOTA **and** the improvement survives a
+    cost-adjusted margin (turnover-aware, using the `_with_cost` metrics).
+  - `decision = (holdout_beats_sota AND dsr_ok AND cost_margin_ok)`.
+- **v1 — purged/embargoed cross-validation.** Replace the single train/valid/test split with
+  purged K-fold + embargo to kill leakage across the label horizon (label is
+  `Ref($close,-2)/Ref($close,-1)-1`, so embargo ≥ 2 days). This requires touching how segments are
+  materialized in the qlib templates (`scenarios/qlib/experiment/*/conf_*.yaml`) and the runner.
+- **v2 — record the guardrail stats in the trace** so proposals and the dashboard can see
+  trial count, DSR, and holdout-vs-selection gaps (detects overfitting drift over the run).
+
+**Wiring (no core edits needed):** set env vars to point the summarizer slots at the new class:
+```bash
+QLIB_QUANT_FACTOR_SUMMARIZER=<fork_pkg>.guardrail.GuardrailFactorFeedback
+QLIB_QUANT_MODEL_SUMMARIZER=<fork_pkg>.guardrail.GuardrailModelFeedback
+```
+(or edit the defaults in `app/qlib_rd_loop/conf.py`). Subclass the existing
+`QlibFactorExperiment2Feedback`/`QlibModelExperiment2Feedback` to reuse their prompt plumbing.
+
+**Acceptance test:** run ~30–50 loop iterations; confirm (a) promotions require holdout
+improvement, (b) DSR drops as trial count grows and blocks marginal "winners," (c) a deliberately
+overfit factor (e.g. a high in-sample IC, noisy OOS) is *rejected*.
+
+---
+
+## 8. Claude backend wiring
+
+RD-Agent defaults to LiteLLM. Point it at Claude via `.env` at repo root. The README shows the
+OpenAI-style shape (`CHAT_MODEL`, `EMBEDDING_MODEL`, `OPENAI_API_BASE`). For Claude through
+LiteLLM, use LiteLLM's Anthropic provider naming and `ANTHROPIC_API_KEY`, e.g.:
+
+```bash
+# .env  (verify exact keys against rdagent/oai/ and the RD-Agent LiteLLM docs before relying on it)
+CHAT_MODEL=claude-opus-4-8            # or the LiteLLM-qualified name, e.g. anthropic/claude-...
+ANTHROPIC_API_KEY=sk-ant-...
+EMBEDDING_MODEL=text-embedding-3-small  # embeddings may need a separate provider; the knowledge
+                                        # base uses embeddings — decide provider or disable RAG
+```
+
+**Open item for the next session:** confirm the exact LiteLLM backend selector and env keys in
+`rdagent/oai/` (there is a backend setting) and how embeddings are configured, since the
+knowledge base needs an embedding model. Anthropic has no embeddings API — either route embeddings
+to another provider or make the KB embedding-optional.
+
+---
+
+## 9. Phased plan
+
+- **Phase 0 — Reproduce baseline.** Install fork, Docker up, qlib data ready, `rdagent fin_quant`
+  runs a few loops on the stock config. Confirm you can read `exp.result` and the trace log. *Gate:
+  a clean baseline run.*
+- **Phase 1 — Claude backend.** LiteLLM → Claude; resolve embeddings. *Gate: loop runs on Claude.*
+- **Phase 2 — Guardrail v0 (first real deliverable).** Locked holdout + trial-aware DSR gate as a
+  drop-in summarizer. *Gate: overfit factor rejected; promotions require OOS improvement.*
+- **Phase 3 — Knowledge substrate.** Curated qlib capability corpus (operators, Alpha158/360
+  handlers, model cards, metric glossary) injected into the proposal context / KB. *Gate: proposals
+  reference real operators/fields and stop hallucinating expressions.*
+- **Phase 4 — Guardrail v1 (purged CV).** Leakage-safe evaluation in the qlib templates/runner.
+- **Phase 5 — Interface/dashboard.** Read the trace + guardrail stats; hypothesis tree, OOS-vs-
+  selection gaps, DSR over trials. (RD-Agent ships a `rdagent ui` / `server_ui` — extend rather
+  than rebuild.)
+- **Phase 6 — Optional Claude-native surface.** Wrap the loop / qlib tools as an MCP server or
+  Claude Code skills if a Claude-native operator UX is wanted.
+
+---
+
+## 10. Risks & open questions
+
+- **Upstream drift.** RD-Agent is active; keep the fork's changes confined to the plug-in modules
+  and a thin `conf.py` override to make periodic merges cheap. Avoid editing `core/`.
+- **Docker dependency** is hard (qlib runs in a container). CI and any cloud runs need Docker.
+- **Embeddings/KB provider** unresolved with a Claude chat backend (Anthropic has no embeddings) —
+  decide provider or make RAG optional (see §8).
+- **DSR inputs.** Deflated Sharpe needs the trial count and the distribution/variance of trial
+  Sharpes; ensure the trace accumulates enough per-trial stats. May need to persist Sharpe (not
+  just IC/return/drawdown) per experiment.
+- **Cost.** Each loop iteration = LLM calls + a full Dockerized qlib backtest. Budget and cap
+  `loop_n`; use cheap pre-checks before full backtests where possible.
+- **"test" segment reuse.** The stock config selects on the 2017–2020 test segment. The guardrail
+  redefines what the loop is allowed to select on; make sure the holdout is genuinely untouched by
+  proposal context and feedback.
+
+---
+
+## Appendix A — Key file map (RD-Agent)
+
+| Path | Role |
+|---|---|
+| `rdagent/components/workflow/rd_loop.py` | Generic loop `RDLoop` (steps: direct_exp_gen, coding, running, feedback, record) |
+| `rdagent/app/qlib_rd_loop/quant.py` | `QuantRDLoop` — factor+model joint loop + `main()` |
+| `rdagent/app/qlib_rd_loop/{factor,model,factor_from_report}.py` | Single-mode loops |
+| `rdagent/app/qlib_rd_loop/conf.py` | `QuantBasePropSetting` etc. — the pluggable config (env prefix `QLIB_QUANT_`) |
+| `rdagent/app/cli.py` | `rdagent fin_quant / fin_factor / fin_model / fin_factor_report / ui` |
+| `rdagent/core/proposal.py` | `Hypothesis`, `HypothesisFeedback`, `Trace`, `Experiment2Feedback`, `HypothesisGen`, `Hypothesis2Experiment` |
+| `rdagent/scenarios/qlib/developer/feedback.py` | Current LLM-judge evaluation (**replace this**) |
+| `rdagent/scenarios/qlib/developer/{factor_runner,model_runner}.py` | Run qlib for factor/model |
+| `rdagent/scenarios/qlib/proposal/{quant,factor,model}_proposal.py` | Hypothesis generators |
+| `rdagent/scenarios/qlib/experiment/*/conf_*.yaml` | qlib workflow templates (where code is injected) |
+| `rdagent/scenarios/qlib/prompts.yaml` | Scenario/context prompts (Gap 2 substrate hook) |
+| `rdagent/components/knowledge_management/{vector_base,graph}.py` | Vector store + knowledge graph (RAG) |
+| `rdagent/utils/env.py` | Docker/Local execution env for qlib |
+| `rdagent/utils/qlib.py` | qlib helpers (`ALPHA20`, `validate_qlib_features`) |
+| `rdagent/oai/` | LiteLLM backend (point at Claude here) |
+
+## Appendix B — Config slots to override (env prefix `QLIB_QUANT_`)
+
+`scen`, `quant_hypothesis_gen`, `factor_hypothesis2experiment`, `model_hypothesis2experiment`,
+`factor_coder`, `model_coder`, `factor_runner`, `model_runner`, **`factor_summarizer`**,
+**`model_summarizer`**, `action_selection` (`bandit|llm|random`),
+`train_start/end`, `valid_start/end`, `test_start/end`, `evolving_n`.
+
+## Appendix C — Run commands
+
+```bash
+# reproduce baseline (factor+model joint loop)
+rdagent fin_quant
+# factor-only / model-only
+rdagent fin_factor
+rdagent fin_model
+# resume a session
+rdagent fin_quant --path <LOG_PATH>/__session__/<i>/<step> --step_n 1
+# view traces
+rdagent ui            # (server_ui for the newer frontend)
+# environment sanity
+rdagent health_check
+```
+
+---
+
+*Prepared from a direct read of the RD-Agent source. Claims about the guardrail gap, the pluggable
+config, the loop structure, Docker execution, and the file map were verified against the code;
+items flagged "verify" (exact LiteLLM/embedding env keys) were not run and should be confirmed in
+the fork.*

--- a/docs/proposals/0002-agent-driven-loop.md
+++ b/docs/proposals/0002-agent-driven-loop.md
@@ -1,0 +1,249 @@
+# ADR 0002 — The agent *is* the loop: RD-Agent machinery as deterministic tools
+
+- **Status:** Accepted
+- **Date:** 2026-07-06
+- **Deciders:** repo owner
+- **Relationship to 0001:** **Amends [ADR 0001](0001-autonomous-quant-rd-loop.md).** Keeps 0001's
+  vision (autonomous qlib alpha search with honest evaluation), its guardrail design (§7), and its
+  file map. **Supersedes 0001's execution-mode decision (§6):** we do *not* run RD-Agent's autonomous
+  program and swap three LLM components. Instead, **this Claude Code session's agent drives the loop
+  directly**, calling RD-Agent's deterministic machinery as tools.
+
+> Like 0001, this is both a decision record and a cold-start handoff. A fresh session should be able
+> to read this and continue. Paths are relative to the repo root.
+
+---
+
+## 1. TL;DR decision
+
+RD-Agent's loop routes *all* intelligence through one choke point —
+`APIBackend().build_messages_and_create_chat_completion(...)` — i.e. it phones a *second, external*
+LLM for every propose / code / judge step. That is what needs `.env` + `ANTHROPIC_API_KEY`, and it is
+why `python rdagent/app/qlib_rd_loop/quant.py` fails with no credentials.
+
+**We already have an LLM with tools: this session's agent.** So instead of paying an API to run a
+worse-integrated copy of the agent, **the agent becomes the brain** (propose hypotheses, write
+factor/model code, judge results) and RD-Agent's **LLM-free machinery** — Dockerized qlib execution,
+the trace ledger, and a statistical guardrail — is exposed as **deterministic tools the agent calls**.
+
+Consequences: **no second API key**, every reasoning step is visible in the agent transcript, and two
+of 0001's open problems dissolve (see §6). The cost: the loop is **attended and low-throughput**
+(a handful of honest iterations per session) rather than **unattended at scale** (hundreds of loops
+overnight). We chose transparency + honest evaluation over unattended throughput. If unattended scale
+becomes the goal, 0001's program-driven path is the fallback (point LiteLLM at Claude via `.env`).
+
+---
+
+## 2. For the next session — start here
+
+**What is true right now (verified this session):**
+- **Slice 1 is proven.** A cold session drove a Dockerized qlib backtest end-to-end and got real
+  metrics back, with **no `.env` and no LLM call in the path**. See §4.
+- The tools exist: **`agent_loop/run_qlib.py`** (execute) and **`agent_loop/guardrail.py`** (the
+  deterministic promote/reject gate). Both are LLM-free.
+- **Phase B is done too:** the guardrail rejects a deliberately overfit factor and applies a real
+  Deflated-Sharpe multiple-testing haircut. Tests: `agent_loop/tests/test_guardrail.py` (4 passing).
+- `agent_loop/` is a **new top-level package kept outside `rdagent/`** so upstream merges stay cheap
+  (0001 §10). Do not put loop-driving logic inside `rdagent/`.
+
+**Environment facts (this machine, verified):**
+- Host env: conda env **`rdagent`** (Python 3.10.20), `rdagent` editable-installed
+  (`pip install -e .`). Run tools with `~/anaconda3/envs/rdagent/bin/python`. (The `base` env is
+  Python 3.11 and is missing deps — do not use it.)
+- qlib runs in Docker image **`local_qlib:latest`** (already built). Docker daemon is up.
+- qlib data: **`~/.qlib/qlib_data/cn_data`** is extracted (features/instruments/calendars present).
+  The container mounts `~/.qlib/` → `/root/.qlib/`.
+- **Two env fixes are required and are baked into `run_qlib.py`:**
+  1. Force **`env_type=docker`**. The default is `conda` (`MODEL_CoSTEER_ENV_TYPE`), which would
+     auto-create a heavy `rdagent4qlib` conda env (qlib+torch). The Docker image is already provisioned.
+  2. Pass **`MLFLOW_ALLOW_FILE_STORE=true`** into the container — its newer mlflow refuses the
+     file-store tracking backend otherwise (hard-fails the run with no result file).
+- GPU: this is a Mac; `QlibDockerConf.enable_gpu` defaults `True` but auto-disables when unavailable.
+  `run_qlib.py` sets `QLIB_DOCKER_ENABLE_GPU=False` to skip the probe.
+
+**Next deliverables (in order):**
+1. ~~`guardrail` tool~~ — **DONE** (`agent_loop/guardrail.py`). See §5b.
+2. **`trace`** tool — a simple JSON/SQLite DAG ledger the agent owns (exp + agent's qualitative
+   feedback + guardrail stats). Schema is already defined in `guardrail.py` (the `trials` list it
+   reads). Do *not* reuse `LoopBase.load`/checkpoint machinery — it is coupled to the program loop.
+3. **factor injection path** — exercise `run_qlib.py --factors` with a real hand-written factor
+   (`combined_factors_df.parquet`) so the agent can test its own alpha, not just the Alpha20 baseline.
+   This is what produces the candidate + locked-holdout runs the guardrail consumes.
+4. **Claude Code skill `quant-rd-loop`** — the one-iteration recipe wiring the agent + the three tools.
+
+---
+
+## 3. Architecture: who does what
+
+| R&D stage | Brain | Hands (deterministic tool) |
+|---|---|---|
+| Propose / Formalize | **agent** (reads scenario + knowledge files + trace SOTA, writes hypothesis) | — |
+| Implement | **agent** (writes factor expr / `model.py`) | — |
+| Execute | — | **`agent_loop/run_qlib.py`** → `QlibFBWorkspace.execute()` → Docker qlib |
+| Evaluate (decision) | — | **`guardrail`** (holdout + Deflated Sharpe + cost margin) — *not an LLM* |
+| Evaluate (qualitative) | **agent** (observations, next-hypothesis) | — |
+| Memorize | — | **`trace`** (JSON/SQLite DAG ledger) |
+
+The agent is `HypothesisGen` + coder + the *qualitative* half of feedback. The promote/reject decision
+is deterministic Python — which is exactly what 0001 Gap 1 demanded (stop letting an LLM eyeball
+test-segment metrics). Here that is **structural**, not a swapped module.
+
+---
+
+## 4. Verified spine (slice 1)
+
+**The whole execution path is LLM-free.** The only file under `rdagent/scenarios/qlib/developer/`
+that imports `APIBackend` is `feedback.py` — the component 0001 replaces. Both runners
+(`factor_runner.py`, `model_runner.py`) and `utils/env.py` are LLM-free. Every backtest reduces to:
+
+```python
+# rdagent/scenarios/qlib/experiment/workspace.py — QlibFBWorkspace.execute()
+result, stdout = exp.experiment_workspace.execute(qlib_config_name="conf_*.yaml", run_env=env_to_use)
+exp.result = result   # pandas Series, indexed by metric name
+```
+
+`run_env` carries `train_start/end, valid_start/end, test_start/end` and is passed as **container env
+vars**, which qlib's `qrun` substitutes into the YAML template's Jinja fields. **This is the holdout
+seam:** the guardrail controls which date segments a backtest is allowed to see, with no core edits.
+
+**Proof run** (`conf_baseline.yaml`, Alpha20, train 2015–16 / valid 2017 / test 2018), metrics returned:
+
+```
+IC 0.0277   Rank IC 0.0283   ICIR 0.254   Rank ICIR 0.250
+1day.excess_return_with_cost.annualized_return -0.0195
+1day.excess_return_with_cost.max_drawdown      -0.0797
+1day.excess_return_with_cost.information_ratio -0.245
+```
+
+(Weak numbers — it's a deliberately tiny baseline; the point is the spine.) The Series contains
+**exactly** the `IMPORTANT_METRICS` from `feedback.py` (`IC`, `...with_cost.annualized_return`,
+`...with_cost.max_drawdown`) plus Rank IC/ICIR/information_ratio — the guardrail's inputs.
+
+---
+
+## 5. The `run_qlib` tool (built)
+
+`agent_loop/run_qlib.py` — `python -m agent_loop.run_qlib [flags]`. Key flags: `--conf` (template
+yaml), `--template factor|model`, `--factors <parquet>` (inject `combined_factors_df.parquet`),
+`--features <json>` (default Alpha20), the six date-segment flags, `--env docker|conda`, `--gpu`,
+`--timeout`, `--out <json>`. Returns/dumps `{workspace, conf, segments, metrics}`. It mutates
+`MODEL_COSTEER_SETTINGS.env_type` at runtime and injects `MLFLOW_ALLOW_FILE_STORE`/GPU env — a caller
+never needs a `.env`.
+
+---
+
+## 5b. The `guardrail` tool (built)
+
+`agent_loop/guardrail.py` — `python -m agent_loop.guardrail --candidate <sel.json> --holdout <hold.json>
+[--trace <trace.json>] [--sota <sel.json>]`. Deterministic promote/reject; **no LLM**. Promotes only if
+**all** gates pass:
+
+1. **holdout_ok** — beats the current SOTA on a locked holdout segment (or clears a floor if no incumbent).
+2. **dsr_ok** — Deflated Sharpe Ratio (Bailey & López de Prado 2014) ≥ threshold (default 0.95). DSR
+   reads the raw daily excess-return-with-cost series from `<workspace>/ret.pkl` for honest T / skew /
+   kurtosis, then haircuts the Sharpe by the trial count `N = len(trace.trials)+1` and the trial-Sharpe
+   dispersion. As `N` grows, the bar rises.
+3. **net_positive** — net-of-cost information ratio > 0 (reject pure gross winners).
+4. **beats_sota_net** — net-of-cost IR beats the incumbent by `--cost_margin`.
+
+**Acceptance results** (`agent_loop/tests/test_guardrail.py`, 4 passing): an overfit factor (strong
+selection Sharpe, poor holdout Rank IC) is rejected on the holdout gate; and a Sharpe-2.2 candidate that
+is promoted at `N=1` (DSR 0.98) is rejected after 200 trials (DSR 0.35) — the multiple-testing haircut
+biting exactly as designed. The trace JSON schema the guardrail reads is the contract for the Phase C
+`trace` tool.
+
+## 6. What dissolves vs 0001
+
+- **Embeddings / RAG (0001 §8, §10 open item): gone.** RAG existed to feed a *remote* LLM past
+  context. The agent retrieves by reading the knowledge-substrate files directly. Anthropic-has-no-
+  embeddings is a non-problem here.
+- **LLM-judge eval gap (0001 §7, Gap 1): structural, not a swap.** The decision is deterministic Python
+  the agent calls; there is no LLM in the promote/reject path by construction.
+- **Still true from 0001:** Docker dependency stays (qlib runs in a container — but that is local
+  execution, not an API call). The guardrail's statistical design (holdout + Deflated Sharpe + cost
+  margin, purged CV later) is unchanged — see 0001 §7.
+
+---
+
+## 7. What we give up (and the fallback)
+
+Program-driven RD-Agent buys **unattended overnight autonomy**: parallel loops, bandit factor-vs-model
+selection, auto-retry evolving coder, hundreds of iterations. Agent-driven is **attended and
+low-throughput** by nature. If throughput/scale becomes the goal, the fallback is 0001's path: keep
+`quant.py`, point `LiteLLMAPIBackend` at Claude via `.env`, and swap the summarizer for the guardrail
+module. The two paths **share** the guardrail and the knowledge substrate, so that work is not wasted.
+
+---
+
+## 8. Phased plan (supersedes 0001 §9 Phases 0–2)
+
+- **Phase A — spine (DONE).** `run_qlib` tool; slice-1 baseline backtest returns real metrics, no key.
+- **Phase B — guardrail tool (DONE).** Deterministic holdout + Deflated Sharpe + cost margin (0001 §7
+  v0), consuming `run_qlib` metric JSON. *Gate met: overfit factor rejected; DSR haircut blocks a
+  marginal winner as trial count grows.* See §5b.
+- **Phase C — trace tool.** JSON/SQLite DAG ledger owned by `agent_loop`. *Gate: sessions resume.*
+- **Phase D — factor path.** Hand-written factor via `--factors`; agent tests its own alpha end-to-end.
+- **Phase E — skill.** `quant-rd-loop` Claude Code skill = the one-iteration recipe over A–D.
+- **Phase F — knowledge substrate** (0001 §Gap 2 / Phase 3): curated qlib operator/handler/model-card
+  corpus the agent reads directly. Later: purged/embargoed CV (0001 §7 v1).
+
+---
+
+## 9. Operational model — long-running jobs without stalling the session
+
+**The core tension of agent-driven execution:** every loop iteration pairs *cheap* agent reasoning
+(propose / code / judge — seconds) with an *expensive* deterministic job (a Dockerized qlib backtest is
+2–4 min today on a short segment; a full universe, GPU model training, or a purged-CV sweep will be tens
+of minutes to hours). If the session blocks on each job, the agent — the scarce resource — sits idle.
+This is a first-class design constraint, not an afterthought, and it shapes how the loop is run.
+
+**How the loop stays active while a job runs:**
+
+- **Background + notify, never block.** Launch backtests as background jobs (`run_in_background`); the
+  harness re-invokes the agent when the job exits. The agent does *useful* filler work in the gap:
+  propose the next hypothesis, write/refine a tool, update this ADR, or do git/PR housekeeping. (This
+  very document was extended, and the branch/PR prepared, while a 4-backtest Phase-D run was executing.)
+- **Parallel fan-out.** Independent backtests can run as concurrent background jobs (e.g. baseline vs
+  candidate × selection vs holdout — 4 at once). Caveat: qlib's Docker env mounts a shared cache
+  (`/tmp/full` → `workspace_cache`); heavy parallelism can race on it, so cap concurrency or isolate
+  caches per job.
+- **File-based state = interruptible/resumable.** The loop's state is *on disk* (run JSONs, the trace
+  ledger), not in a live Python process. A session can end mid-flight and a fresh one resumes from the
+  ledger — a structural advantage over the program-driven loop, whose state lives in `LoopBase` memory
+  and needs its checkpoint machinery. Design tools to be **idempotent and re-entrant**: write results to
+  a stable path, and treat "job already produced its JSON" as success.
+- **Polling only when the harness can't notify.** For state the harness cannot observe (a CI run, a
+  remote queue), poll with a `Monitor` until-loop. Do **not** hand-roll `sleep` in a foreground shell —
+  the harness blocks long foreground sleeps by design.
+- **Self-paced loops.** For an unattended cadence, schedule the next iteration with a wake-up timer.
+  Match the delay to what you're waiting on and to the prompt-cache window (~5 min): sub-5-min polls
+  keep the cache warm for a job about to finish; for long jobs, sleep long (20–60 min) and let the job's
+  own completion event be the primary wake signal, with the timer as a fallback.
+
+**Practical gotchas discovered during bring-up (all now handled in `agent_loop/`):**
+
+- Foreground `sleep` is blocked — use background jobs or a `Monitor` until-loop to wait on a condition.
+- On macOS, qlib/`D.features` uses the `spawn` multiprocessing start method; any host-side factor-
+  computation script **must** guard its body with `if __name__ == "__main__":` or it crashes with
+  `freeze_support()` / bootstrapping errors.
+- A background command whose stdout is filtered through a pipe can look "empty" mid-run; write full
+  output to a log file and inspect that, rather than trusting a grep'd tail.
+
+**Implication for throughput.** Even with backgrounding, agent-driven is bounded by *attended* wall
+time: the agent must be re-invoked to advance. That is the deliberate trade in §7. The mitigations above
+(parallel fan-out + filler work + resumable file state) recover a lot of it, but if the goal becomes
+"hundreds of iterations unattended overnight," the program-driven fallback (§7) is the right tool.
+
+---
+
+## Appendix — reproduce slice 1
+
+```bash
+PY=~/anaconda3/envs/rdagent/bin/python
+$PY -m agent_loop.run_qlib --conf conf_baseline.yaml \
+  --train_start 2015-01-01 --train_end 2016-12-31 \
+  --valid_start 2017-01-01 --valid_end 2017-12-31 \
+  --test_start 2018-01-01 --test_end 2018-12-31 --out /tmp/res.json
+# Needs: Docker up, local_qlib:latest image, ~/.qlib/qlib_data/cn_data extracted.
+# Does NOT need: .env, ANTHROPIC_API_KEY, or any LLM endpoint.
+```


### PR DESCRIPTION
See docs/proposals/0002-agent-driven-loop.md. Adds agent_loop/ (LLM-free tools the session agent drives): run_qlib (Docker qlib backtest) + guardrail (deterministic holdout + Deflated Sharpe promote/reject). 4 passing guardrail tests. No .env / API key in the execution path.

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1438.org.readthedocs.build/en/1438/

<!-- readthedocs-preview RDAgent end -->