### PR TITLE
fix(qlib): isolate holdout evaluation from iterative research feedback

### DIFF
--- a/rdagent/app/qlib_rd_loop/factor.py
+++ b/rdagent/app/qlib_rd_loop/factor.py
@@ -26,6 +26,17 @@ class FactorRDLoop(RDLoop):
         logger.log_object(exp, tag="runner result")
         return exp
 
+    def _run_final_holdout(self):
+        """Evaluate the selected experiment after research has stopped."""
+        exp = self.trace.get_sota_experiment()
+        if exp is None:
+            logger.warning("No accepted factor experiment is available for final holdout evaluation.")
+            return None
+
+        result = self.runner.evaluate_holdout(exp)
+        logger.log_object(result, tag="final holdout result")
+        return result
+
 
 def main(
     path: Optional[str] = None,
@@ -35,6 +46,7 @@ def main(
     checkout: bool = True,
     checkout_path: Optional[str] = None,
     base_features_path: Optional[str] = None,
+    run_final_holdout: bool = False,
     **kwargs,
 ):
     """
@@ -60,6 +72,8 @@ def main(
         factor_loop._set_interactor(*kwargs["user_interaction_queues"])
         factor_loop._interact_init_params()
     asyncio.run(factor_loop.run(step_n=step_n, loop_n=loop_n, all_duration=all_duration))
+    if run_final_holdout:
+        factor_loop._run_final_holdout()
 
 
 if __name__ == "__main__":

--- a/rdagent/scenarios/qlib/developer/factor_runner.py
+++ b/rdagent/scenarios/qlib/developer/factor_runner.py
@@ -60,8 +60,46 @@ class QlibFactorRunner(CachedRunner[QlibFactorExperiment]):
         IC_max = IC_max.unstack().max(axis=0)
         return new_feature.iloc[:, IC_max[IC_max < 0.99].index]
 
+    def _get_run_env(self, exp: QlibFactorExperiment, use_holdout: bool) -> dict[str, str]:
+        """Build Qlib's runtime environment for search or final holdout evaluation.
+
+        Qlib's SignalRecord and PortAnaRecord report metrics from the dataset
+        ``test`` segment. During iterative research, bind that internal
+        segment to validation so the configured test period remains unseen.
+        """
+        fbps = FactorBasePropSetting()
+        evaluation_start = fbps.test_start if use_holdout else fbps.valid_start
+        evaluation_end = fbps.test_end if use_holdout else fbps.valid_end
+        env_to_use = {
+            "PYTHONPATH": "./",
+            "train_start": fbps.train_start,
+            "train_end": fbps.train_end,
+            "valid_start": fbps.valid_start,
+            "valid_end": fbps.valid_end,
+            "test_start": evaluation_start,
+            "feature_names": str(list(exp.base_features.keys())),
+            "feature_expressions": str(list(exp.base_features.values())),
+        }
+        if evaluation_end is not None:
+            env_to_use["test_end"] = evaluation_end
+        return env_to_use
+
     @cache_with_pickle(CachedRunner.get_cache_key, CachedRunner.assign_cached_result)
     def develop(self, exp: QlibFactorExperiment) -> QlibFactorExperiment:
+        """Run one search iteration using validation-only evaluation metrics."""
+        result, stdout = self._run_experiment(exp, use_holdout=False)
+        exp.result = result
+        exp.stdout = stdout
+        return exp
+
+    def evaluate_holdout(self, exp: QlibFactorExperiment) -> pd.Series:
+        """Evaluate a frozen experiment on test without updating search state."""
+        result, stdout = self._run_experiment(exp, use_holdout=True)
+        exp.holdout_result = result
+        exp.holdout_stdout = stdout
+        return result
+
+    def _run_experiment(self, exp: QlibFactorExperiment, use_holdout: bool) -> tuple[pd.Series, str]:
         """
         Generate the experiment by processing and combining factor data,
         then passing the combined data to Docker for backtest results.
@@ -70,19 +108,7 @@ class QlibFactorRunner(CachedRunner[QlibFactorExperiment]):
             logger.info(f"Baseline experiment execution ...")
             exp.based_experiments[-1] = self.develop(exp.based_experiments[-1])
 
-        fbps = FactorBasePropSetting()
-        env_to_use = {
-            "PYTHONPATH": "./",
-            "train_start": fbps.train_start,
-            "train_end": fbps.train_end,
-            "valid_start": fbps.valid_start,
-            "valid_end": fbps.valid_end,
-            "test_start": fbps.test_start,
-            "feature_names": str(list(exp.base_features.keys())),
-            "feature_expressions": str(list(exp.base_features.values())),
-        }
-        if fbps.test_end is not None:
-            env_to_use.update({"test_end": fbps.test_end})
+        env_to_use = self._get_run_env(exp, use_holdout=use_holdout)
 
         if exp.based_experiments:
             SOTA_factor = None
@@ -196,7 +222,4 @@ class QlibFactorRunner(CachedRunner[QlibFactorExperiment]):
             logger.error(f"Failed to run this experiment, because {stdout}")
             raise FactorEmptyError(f"Failed to run this experiment, because {stdout}")
 
-        exp.result = result
-        exp.stdout = stdout
-
-        return exp
+        return result, stdout

--- a/rdagent/scenarios/qlib/experiment/factor_experiment.py
+++ b/rdagent/scenarios/qlib/experiment/factor_experiment.py
@@ -21,6 +21,8 @@ class QlibFactorExperiment(FactorExperiment[FactorTask, QlibFBWorkspace, FactorF
         super().__init__(*args, **kwargs)
         self.experiment_workspace = QlibFBWorkspace(template_folder_path=Path(__file__).parent / "factor_template")
         self.stdout = ""
+        self.holdout_result = None
+        self.holdout_stdout = ""
         self.base_features: dict[str, str] = (
             {}
         )  # Qlib features in operator form, e.g., "RESI5": "Resi($close, 5)/$close"

--- a/test/qlib/test_factor_holdout.py
+++ b/test/qlib/test_factor_holdout.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pandas as pd
+from rdagent.scenarios.qlib.developer.factor_runner import QlibFactorRunner
+
+IMPORTANT_METRICS = [
+    "IC",
+    "1day.excess_return_with_cost.annualized_return",
+    "1day.excess_return_with_cost.max_drawdown",
+]
+
+
+def _result(value: float) -> pd.Series:
+    return pd.Series(dict.fromkeys(IMPORTANT_METRICS, value))
+
+
+def test_factor_search_uses_validation_as_qlib_evaluation_segment():
+    props = SimpleNamespace(
+        train_start="2008-01-01",
+        train_end="2014-12-31",
+        valid_start="2015-01-01",
+        valid_end="2016-12-31",
+        test_start="2017-01-01",
+        test_end="2020-08-01",
+    )
+    exp = Mock(base_features={"factor": "expression"})
+    runner = object.__new__(QlibFactorRunner)
+
+    with patch("rdagent.scenarios.qlib.developer.factor_runner.FactorBasePropSetting", return_value=props):
+        search_env = runner._get_run_env(exp, use_holdout=False)
+        holdout_env = runner._get_run_env(exp, use_holdout=True)
+
+    assert search_env["test_start"] == props.valid_start
+    assert search_env["test_end"] == props.valid_end
+    assert holdout_env["test_start"] == props.test_start
+    assert holdout_env["test_end"] == props.test_end
+
+
+def test_final_holdout_does_not_replace_search_result():
+    search_result = _result(0.02)
+    holdout_result = _result(0.99)
+    exp = Mock(result=search_result)
+    runner = object.__new__(QlibFactorRunner)
+    runner._run_experiment = Mock(return_value=(holdout_result, "holdout stdout"))
+
+    result = runner.evaluate_holdout(exp)
+
+    assert result is holdout_result
+    assert exp.result is search_result
+    assert exp.holdout_result is holdout_result
+    assert exp.holdout_stdout == "holdout stdout"
+


### PR DESCRIPTION
## Summary

- Run iterative Qlib factor evaluations on the validation window, rather than the configured test/holdout window.
- Add an explicit final-holdout path that runs only after the research loop has stopped and stores its result separately.
- Add regression coverage for search-vs-holdout window selection and for preserving search results after final evaluation.

## Root Cause

Qlib's `SignalRecord` and `PortAnaRecord` report metrics from the dataset `test` segment. The factor runner mapped that segment directly to the configured test period, and `read_exp_res.py` exported those metrics into `exp.result`. `QlibFactorExperiment2Feedback` then used `exp.result` to construct iterative LLM feedback and replacement decisions.

## Change

`develop()` now binds Qlib's internal evaluation segment to the configured validation interval. The configured test period is only used by `evaluate_holdout()`, which writes `holdout_result` and `holdout_stdout` without replacing `exp.result` or triggering feedback/recording. `main(..., run_final_holdout=True)` invokes that final evaluation after `RDLoop.run()` returns.

The final-holdout method is private so `LoopMeta` does not register it as an iterative workflow step.

## Validation

- `python -m compileall -q rdagent/scenarios/qlib/developer/factor_runner.py rdagent/scenarios/qlib/experiment/factor_experiment.py rdagent/app/qlib_rd_loop/factor.py test/qlib/test_factor_holdout.py`
- `python -m ruff check --no-fix --select E9,F821,F822,F823 rdagent/scenarios/qlib/developer/factor_runner.py rdagent/scenarios/qlib/experiment/factor_experiment.py rdagent/app/qlib_rd_loop/factor.py test/qlib/test_factor_holdout.py`

The focused pytest module could not be collected locally because this checkout's Python environment is missing the project's `litellm` runtime dependency. No Qlib, Docker, or model API execution was performed during validation.


<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1442.org.readthedocs.build/en/1442/

<!-- readthedocs-preview RDAgent end -->