### PR TITLE
ci: stabilize CI toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - name: lint test docs and build
         run: make lint docs-gen test-offline # test docs build
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - '3.10'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '22'
 
       - name: Install commitlint
         run: npm install --save-dev @commitlint/{config-conventional,cli}

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,7 +72,7 @@ azureml-mlflow
 types-pytz
 
 # Agent
-pydantic-ai-slim[mcp,openai,prefect]
+pydantic-ai-slim[mcp,openai,prefect]==1.66.0
 nest-asyncio
 
 # visualize SFT train

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -2,7 +2,7 @@
 black
 isort
 mypy
-ruff
+ruff==0.15.12
 toml-sort
 types-PyYAML
 types-psutil


### PR DESCRIPTION
## Summary

- use Node.js 22 for the pull request title lint workflow
- pin Ruff to the last known-good version (`0.15.12`)
- disable matrix fail-fast so Python 3.10 and 3.11 results are both reported

## Validation

- confirmed the current commitlint release supports Node.js 22
- validated the repository commitlint configuration with the updated toolchain
- confirmed Ruff 0.15.12 is available from PyPI
- checked the patch with `git diff --check`

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1445.org.readthedocs.build/en/1445/

<!-- readthedocs-preview RDAgent end -->