### PR TITLE
Fix health check config guardrails

### DIFF
--- a/rdagent/app/utils/health_check.py
+++ b/rdagent/app/utils/health_check.py
@@ -42,10 +42,11 @@ def check_and_list_free_ports(start_port=19899, max_ports=10) -> None:
             if not is_port_in_use(port):
                 free_ports.append(port)
         logger.warning(
-            f"Port 19899 is occupied, please replace it with an available port when running the `rdagent ui/server_ui` command. Available ports: {free_ports}"
+            f"Port {start_port} is occupied, please replace it with an available port when running "
+            f"the `rdagent ui/server_ui` command. Available ports: {free_ports}"
         )
     else:
-        logger.info(f"Port 19899 is not occupied, you can run the `rdagent ui/server_ui` command")
+        logger.info(f"Port {start_port} is not occupied, you can run the `rdagent ui/server_ui` command")
 
 
 def test_chat(chat_model, chat_api_key, chat_api_base):
@@ -119,6 +120,22 @@ def env_check():
         embedding_api_base = chat_api_base
     else:
         logger.error("No valid configuration was found, please check your .env file.")
+        return
+
+    missing_settings = [
+        name
+        for name, value in {
+            "CHAT_MODEL": chat_model,
+            "EMBEDDING_MODEL": embedding_model,
+        }.items()
+        if not value
+    ]
+    if missing_settings:
+        logger.error(
+            f"Missing required model configuration: {', '.join(missing_settings)}. "
+            "Please set them in your .env file before running `rdagent health_check --check-env`."
+        )
+        return
 
     logger.info("🚀 Starting test...\n")
     result_embedding = test_embedding(

--- a/rdagent/app/utils/health_check.py
+++ b/rdagent/app/utils/health_check.py
@@ -99,7 +99,7 @@ def env_check():
             f"You can run a command like this: `dotenv set BACKEND rdagent.oai.backend.LiteLLMAPIBackend`"
         )
 
-    if "DEEPSEEK_API_KEY" in os.environ:
+    if os.getenv("DEEPSEEK_API_KEY"):
         chat_api_key = os.getenv("DEEPSEEK_API_KEY")
         chat_model = os.getenv("CHAT_MODEL")
         embedding_model = os.getenv("EMBEDDING_MODEL")
@@ -111,7 +111,7 @@ def env_check():
             chat_api_base = os.getenv("OPENAI_API_BASE")
         else:
             chat_api_base = None
-    elif "OPENAI_API_KEY" in os.environ:
+    elif os.getenv("OPENAI_API_KEY"):
         chat_api_key = os.getenv("OPENAI_API_KEY")
         chat_api_base = os.getenv("OPENAI_API_BASE")
         chat_model = os.getenv("CHAT_MODEL")

--- a/test/utils/test_health_check.py
+++ b/test/utils/test_health_check.py
@@ -73,6 +73,29 @@ def test_env_check_returns_without_credentials(monkeypatch):
     assert calls == []
 
 
+def test_env_check_returns_with_empty_credentials(monkeypatch):
+    calls = []
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "")
+    monkeypatch.setenv("OPENAI_API_KEY", "")
+    monkeypatch.setenv("CHAT_MODEL", "test-chat")
+    monkeypatch.setenv("EMBEDDING_MODEL", "test-embedding")
+    monkeypatch.setattr(
+        health_check,
+        "test_chat",
+        lambda *args, **kwargs: calls.append("chat"),
+    )
+    monkeypatch.setattr(
+        health_check,
+        "test_embedding",
+        lambda *args, **kwargs: calls.append("embedding"),
+    )
+
+    health_check.env_check()
+
+    assert calls == []
+
+
 def test_env_check_returns_when_required_models_missing(monkeypatch):
     calls = []
 

--- a/test/utils/test_health_check.py
+++ b/test/utils/test_health_check.py
@@ -1,0 +1,103 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+def _load_health_check_module():
+    logger = SimpleNamespace(
+        info=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+        error=lambda *args, **kwargs: None,
+    )
+
+    docker_module = ModuleType("docker")
+    docker_module.from_env = lambda: None
+    docker_module.errors = SimpleNamespace(DockerException=Exception)
+
+    fire_module = ModuleType("fire")
+    fire_module.Fire = lambda *args, **kwargs: None
+
+    litellm_module = ModuleType("litellm")
+    litellm_module.completion = lambda *args, **kwargs: None
+    litellm_module.embedding = lambda *args, **kwargs: None
+
+    litellm_utils_module = ModuleType("litellm.utils")
+    litellm_utils_module.ModelResponse = object
+
+    rdagent_log_module = ModuleType("rdagent.log")
+    rdagent_log_module.rdagent_logger = logger
+
+    rdagent_utils_env_module = ModuleType("rdagent.utils.env")
+    rdagent_utils_env_module.cleanup_container = lambda *args, **kwargs: None
+
+    stubs = {
+        "docker": docker_module,
+        "fire": fire_module,
+        "litellm": litellm_module,
+        "litellm.utils": litellm_utils_module,
+        "rdagent.log": rdagent_log_module,
+        "rdagent.utils.env": rdagent_utils_env_module,
+    }
+
+    previous = {name: sys.modules.get(name) for name in stubs}
+    sys.modules.update(stubs)
+    try:
+        module_path = Path(__file__).resolve().parents[2] / "rdagent" / "app" / "utils" / "health_check.py"
+        spec = importlib.util.spec_from_file_location("test_health_check_module", module_path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec is not None and spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, old in previous.items():
+            if old is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = old
+
+
+health_check = _load_health_check_module()
+
+
+def test_env_check_returns_without_credentials(monkeypatch):
+    calls = []
+
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(health_check, "test_chat", lambda *args, **kwargs: calls.append("chat"))
+    monkeypatch.setattr(health_check, "test_embedding", lambda *args, **kwargs: calls.append("embedding"))
+
+    health_check.env_check()
+
+    assert calls == []
+
+
+def test_env_check_returns_when_required_models_missing(monkeypatch):
+    calls = []
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.delenv("CHAT_MODEL", raising=False)
+    monkeypatch.delenv("EMBEDDING_MODEL", raising=False)
+    monkeypatch.setattr(health_check, "test_chat", lambda *args, **kwargs: calls.append("chat"))
+    monkeypatch.setattr(health_check, "test_embedding", lambda *args, **kwargs: calls.append("embedding"))
+
+    health_check.env_check()
+
+    assert calls == []
+
+
+def test_check_and_list_free_ports_uses_requested_start_port(monkeypatch):
+    messages = []
+
+    monkeypatch.setattr(
+        health_check,
+        "is_port_in_use",
+        lambda port: port == 21000,
+    )
+    monkeypatch.setattr(health_check.logger, "warning", lambda message: messages.append(message))
+
+    health_check.check_and_list_free_ports(start_port=21000, max_ports=3)
+
+    assert messages
+    assert "21000" in messages[0]


### PR DESCRIPTION
## Summary
- Return early when no supported API key is configured, avoiding access to uninitialized variables.
- Return early when required model settings are missing before running LiteLLM checks.
- Report the actual requested start port in health check port messages.
- Add focused tests for missing configuration and custom port reporting.

## Tests
- `python -m pytest test/utils/test_health_check.py`

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1449.org.readthedocs.build/en/1449/

<!-- readthedocs-preview RDAgent end -->