### PR TITLE
fix(data_science): do not treat a tied score as an improvement when minimizing

### DIFF
--- a/rdagent/scenarios/data_science/dev/runner/__init__.py
+++ b/rdagent/scenarios/data_science/dev/runner/__init__.py
@@ -189,7 +189,9 @@ class DSCoSTEERRunner(CoSTEER):
                 return False
             if s1 is None:
                 return True
-            return (s2 > s1) == self.scen.metric_direction
+            # A tie is not an improvement in either direction. Comparing the ">" result
+            # against metric_direction would make minimization accept "not greater than".
+            return s2 > s1 if self.scen.metric_direction else s2 < s1
 
         return compare_scores(base_fb.score, new_fb.score)
 

--- a/test/utils/coder/test_ds_runner.py
+++ b/test/utils/coder/test_ds_runner.py
@@ -1,0 +1,84 @@
+import unittest
+from types import SimpleNamespace
+
+import pytest
+
+from rdagent.components.coder.CoSTEER.evaluators import CoSTEERMultiFeedback
+from rdagent.scenarios.data_science.dev.runner import DSCoSTEERRunner
+from rdagent.scenarios.data_science.dev.runner.eval import DSRunnerFeedback
+
+
+def build_feedback(score, acceptable=True):
+    return CoSTEERMultiFeedback(
+        [
+            DSRunnerFeedback(
+                execution="executed",
+                return_checking="checked",
+                code="code",
+                final_decision=True,
+                acceptable=acceptable,
+                score=score,
+            ),
+        ],
+    )
+
+
+def build_runner(metric_direction):
+    """Build a runner that only carries the scenario attribute `should_use_new_evo` reads."""
+    runner = object.__new__(DSCoSTEERRunner)
+    runner.scen = SimpleNamespace(metric_direction=metric_direction)
+    return runner
+
+
+@pytest.mark.offline
+class DSCoSTEERRunnerScorePolicyTest(unittest.TestCase):
+    """`should_use_new_evo` must treat a tie the same way for both metric directions."""
+
+    def test_tie_is_not_an_improvement_when_minimizing(self):
+        runner = build_runner(metric_direction=False)
+        self.assertFalse(runner.should_use_new_evo(build_feedback(1.0), build_feedback(1.0)))
+
+    def test_tie_is_not_an_improvement_when_maximizing(self):
+        runner = build_runner(metric_direction=True)
+        self.assertFalse(runner.should_use_new_evo(build_feedback(1.0), build_feedback(1.0)))
+
+    def test_lower_score_is_an_improvement_when_minimizing(self):
+        runner = build_runner(metric_direction=False)
+        self.assertTrue(runner.should_use_new_evo(build_feedback(1.0), build_feedback(0.5)))
+
+    def test_higher_score_is_not_an_improvement_when_minimizing(self):
+        runner = build_runner(metric_direction=False)
+        self.assertFalse(runner.should_use_new_evo(build_feedback(1.0), build_feedback(1.5)))
+
+    def test_higher_score_is_an_improvement_when_maximizing(self):
+        runner = build_runner(metric_direction=True)
+        self.assertTrue(runner.should_use_new_evo(build_feedback(1.0), build_feedback(1.5)))
+
+    def test_lower_score_is_not_an_improvement_when_maximizing(self):
+        runner = build_runner(metric_direction=True)
+        self.assertFalse(runner.should_use_new_evo(build_feedback(1.0), build_feedback(0.5)))
+
+    def test_missing_base_feedback_is_accepted(self):
+        for metric_direction in (True, False):
+            runner = build_runner(metric_direction=metric_direction)
+            self.assertTrue(runner.should_use_new_evo(None, build_feedback(1.0)))
+
+    def test_missing_new_score_is_rejected(self):
+        for metric_direction in (True, False):
+            runner = build_runner(metric_direction=metric_direction)
+            self.assertFalse(runner.should_use_new_evo(build_feedback(1.0), build_feedback(None)))
+
+    def test_missing_base_score_is_accepted(self):
+        for metric_direction in (True, False):
+            runner = build_runner(metric_direction=metric_direction)
+            self.assertTrue(runner.should_use_new_evo(build_feedback(None), build_feedback(1.0)))
+
+    def test_unacceptable_feedback_is_rejected(self):
+        runner = build_runner(metric_direction=False)
+        self.assertFalse(
+            runner.should_use_new_evo(build_feedback(1.0), build_feedback(0.5, acceptable=False)),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1455. Thanks to @yifanxiong272 for the report and the clear reproduction.

## Problem

`DSCoSTEERRunner.should_use_new_evo` compared the `>` result against `metric_direction`:

```python
return (s2 > s1) == self.scen.metric_direction
```

- `metric_direction=True` (higher is better) → `s2 > s1`. A tie is correctly rejected.
- `metric_direction=False` (lower is better) → `not (s2 > s1)`, i.e. `s2 <= s1`. **A tie is accepted.**

So minimization used "not greater than" where it meant "strictly lower".

## Impact

`should_use_new_evo` gates `update_fallback` in `CoSTEER.develop`. When it returns `True`, the fallback experiment and its feedback are `deepcopy`-ed and a workspace checkpoint is created. With a tied score under a minimization objective, an equally-scoring later solution replaces the one already kept, and pays that copy/checkpoint cost — while the same situation under maximization keeps the earlier solution. The two directions disagree on identical input.

## Change

Compare strictly in both directions:

```python
return s2 > s1 if self.scen.metric_direction else s2 < s1
```

The `None` handling above it is unchanged.

## Tests

Adds `test/utils/coder/test_ds_runner.py`, following the existing convention for pure-logic tests in this repo (`unittest.TestCase` + `@pytest.mark.offline`, as in `test/utils/test_misc.py`), so it runs under `make test-offline`.

Ten cases: ties, strict improvements and regressions for both metric directions, plus missing base feedback, missing new score, missing base score, and unacceptable feedback.

On `main`, exactly one case fails:

```
FAILED test_ds_runner.py::DSCoSTEERRunnerScorePolicyTest::test_tie_is_not_an_improvement_when_minimizing
1 failed, 9 passed
```

The other nine pass unchanged, which is the evidence that this fix touches only the tied-minimization path. With the change, all ten pass.

## Verification

`pytest -m "offline" --ignore test/scripts`, same environment, before and after:

| | failed | passed |
|---|---|---|
| `main` | 299 | 2 |
| this branch | 299 | 12 |

Identical failure sets — the 299 are pre-existing import failures in my local environment from missing optional dependencies, unrelated to this change. The +10 is exactly the new tests.

`black --check -l 120` and `isort --check-only` are clean on both changed files. `make ruff` / `make mypy` currently scope to `rdagent/core`, so neither file is in their scope; the ruff findings on the new test file (`ANN201`, `PT009`, `ANN001`) are the same categories already present in `test/utils/test_misc.py` and `test/utils/coder/test_CoSTEER.py`.

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1456.org.readthedocs.build/en/1456/

<!-- readthedocs-preview RDAgent end -->