### PR TITLE
fix: factor execution env crashes when no conda environment is active

### DIFF
--- a/rdagent/components/coder/factor_coder/config.py
+++ b/rdagent/components/coder/factor_coder/config.py
@@ -36,8 +36,18 @@ def get_factor_env(
     enable_cache: Optional[bool] = None,
 ) -> Env:
     conf = FactorCoSTEERSettings()
-    if hasattr(conf, "python_bin"):
+    if os.environ.get("CONDA_DEFAULT_ENV"):
         env = LocalEnv(conf=(CondaConf(conda_env_name=os.environ.get("CONDA_DEFAULT_ENV"))))
+    else:
+        # No conda on this host: run factor code with the current interpreter's env.
+        # (upstream: hasattr(conf, "python_bin") is always True, so the conda branch
+        # crashed with CONDA_DEFAULT_ENV unset)
+        import sys
+        from pathlib import Path as _Path
+
+        from rdagent.utils.env import LocalConf
+
+        env = LocalEnv(conf=LocalConf(bin_path=str(_Path(sys.executable).parent), default_entry="python main.py"))
     env.conf.extra_volumes = extra_volumes.copy()
     env.conf.running_timeout_period = running_timeout_period
     if enable_cache is not None:


### PR DESCRIPTION
## Problem

`get_factor_env()` in `rdagent/components/coder/factor_coder/config.py` unconditionally builds a conda-based environment:

```python
if hasattr(conf, "python_bin"):
    env = LocalEnv(conf=(CondaConf(conda_env_name=os.environ.get("CONDA_DEFAULT_ENV"))))
```

`hasattr(conf, "python_bin")` is always `True` (`python_bin` is a declared settings field with a default), so on any host where the process is not running inside an activated conda environment, `CONDA_DEFAULT_ENV` is unset and `CondaConf` raises:

```
ValidationError: 1 validation error for CondaConf
conda_env_name
  Input should be a valid string [type=string_type, input_value=None, ...]
```

This makes `rdagent fin_factor` crash at loop 0 on any conda-less installation (e.g. a plain venv/uv setup on a fresh Ubuntu server), even though nothing about factor execution actually requires conda.

## Fix

Keep the conda path when `CONDA_DEFAULT_ENV` is set; otherwise fall back to a `LocalEnv` whose `bin_path` is the current interpreter's own bin directory, so factor code runs with the environment RD-Agent itself was installed into.

## Testing

Reproduced on Ubuntu 26.04 with RD-Agent installed in a uv-managed venv (no conda present): `rdagent fin_factor` crashed with the ValidationError above; with this patch, factor implementation, execution, and full qlib R&D loops (15 loops, multiple LLM backends) run to completion. The conda path is unchanged for users inside an activated env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1462.org.readthedocs.build/en/1462/

<!-- readthedocs-preview RDAgent end -->