### PR TITLE
fix: debug data generation crashes on universes with delisted instruments

### DIFF
--- a/rdagent/scenarios/qlib/experiment/factor_data_template/generate.py
+++ b/rdagent/scenarios/qlib/experiment/factor_data_template/generate.py
@@ -12,16 +12,14 @@ data.to_hdf("./daily_pv_all.h5", key="data")
 
 
 fields = ["$open", "$close", "$high", "$low", "$volume", "$factor"]
-data = (
-    (
-        D.features(instruments, fields, start_time="2018-01-01", end_time="2019-12-31", freq="day")
-        .swaplevel()
-        .sort_index()
-    )
-    .swaplevel()
-    .loc[data.reset_index()["instrument"].unique()[:100]]
-    .swaplevel()
+# Debug slice: pick instruments that actually trade in the debug window.
+# (Taking the first 100 of the full-history panel breaks on universes with
+# delisted securities: names dead before 2018 are absent from this window.)
+data_debug = (
+    D.features(instruments, fields, start_time="2018-01-01", end_time="2019-12-31", freq="day")
     .sort_index()
 )
+keep = data_debug.index.get_level_values("instrument").unique()[:100]
+data_debug = data_debug.loc[keep].swaplevel().sort_index()
 
-data.to_hdf("./daily_pv_debug.h5", key="data")
+data_debug.to_hdf("./daily_pv_debug.h5", key="data")


### PR DESCRIPTION
## Problem

`rdagent/scenarios/qlib/experiment/factor_data_template/generate.py` builds the debug slice by taking the first 100 instruments of the **full-history** panel and then `.loc`-ing them inside the 2018–2019 window:

```python
.loc[data.reset_index()["instrument"].unique()[:100]]
```

Any instrument that stopped trading before 2018 (delisted, acquired, bankrupt) is absent from the 2018–2019 frame, so the lookup raises:

```
KeyError: "['P110559' 'P113491' ...] not in index"
```

With the stock cn_data bundle this happens to work because that universe contains only surviving instruments — which is itself worth noting for a quant framework: the data template implicitly assumes a survivorship-biased universe. On any point-in-time bundle that includes dead securities (the kind of data needed for unbiased backtests), data preparation crashes before the first loop.

## Fix

Select the 100 debug instruments **from the debug window itself**, so only instruments that actually trade in 2018–2019 are kept. Behavior on cn_data is unchanged (same instruments end up selected); universes with delisted names now work.

## Testing

Reproduced with a custom survivorship-bias-free S&P 500 bundle (876 point-in-time securities, 215 of which delist inside the sample): `generate.py` crashed with the KeyError above; with this patch it completes, and full `fin_factor` R&D loops run end-to-end on both that bundle and the code path used by cn_data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1463.org.readthedocs.build/en/1463/

<!-- readthedocs-preview RDAgent end -->