### PR TITLE
fix: qlib backtests fail instantly under recent MLflow (filestore gated)

### DIFF
--- a/rdagent/scenarios/qlib/docker/Dockerfile
+++ b/rdagent/scenarios/qlib/docker/Dockerfile
@@ -22,3 +22,6 @@ RUN python -m pip install -e .
 RUN pip install catboost
 RUN pip install xgboost
 RUN pip install tables
+
+# Qlib's recorder uses the ./mlruns filestore; newer MLflow gates it behind this flag.
+ENV MLFLOW_ALLOW_FILE_STORE=true


### PR DESCRIPTION
## Problem

Recent MLflow releases put the filesystem tracking backend (`./mlruns`) into maintenance mode and refuse to use it unless `MLFLOW_ALLOW_FILE_STORE=true` is set:

```
MlflowException: The filesystem tracking backend (e.g., './mlruns') is in maintenance mode
and will not receive further updates. ... If the filesystem backend is required for your
workflow, set MLFLOW_ALLOW_FILE_STORE=true to opt out of this exception.
```

The qlib Docker image (`rdagent/scenarios/qlib/docker/Dockerfile`) installs MLflow unpinned as a qlib dependency, and qlib's recorder is built on the `./mlruns` filestore — so every `qrun` inside the container now dies within seconds. From the R&D loop's perspective the failure is quiet: the `running` step returns almost instantly with no result file, and every experiment is judged on a missing backtest.

## Fix

Set `ENV MLFLOW_ALLOW_FILE_STORE=true` in the image. One line, no behavior change for older MLflow versions (the variable is simply ignored), restores `qrun` under new ones.

## Testing

Reproduced with a freshly built image (Docker 29, image built 2026-08-29): `qrun conf_baseline.yaml` raised the MlflowException immediately; after rebuilding with this ENV, baseline and combined-factor backtests complete and `read_exp_res.py` extracts metrics and portfolio artifacts normally. Verified across multiple full 15-loop `fin_factor` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1464.org.readthedocs.build/en/1464/

<!-- readthedocs-preview RDAgent end -->