### PR TITLE
fix: preserve stdout between EDA blocks

### DIFF
--- a/rdagent/components/coder/data_science/utils.py
+++ b/rdagent/components/coder/data_science/utils.py
@@ -3,4 +3,9 @@ import re
 
 def remove_eda_part(stdout: str) -> str:
     """Data Science scenario have a LLM-based EDA feature. We can remove it when current task does not involve EDA"""
-    return re.sub(r"=== Start of EDA part ===(.*)=== End of EDA part ===", "", stdout, flags=re.DOTALL)
+    return re.sub(
+        r"=== Start of EDA part ===(.*?)=== End of EDA part ===",
+        "",
+        stdout,
+        flags=re.DOTALL,
+    )

--- a/test/utils/coder/test_data_science_utils.py
+++ b/test/utils/coder/test_data_science_utils.py
@@ -1,0 +1,22 @@
+import pytest
+
+from rdagent.components.coder.data_science.utils import remove_eda_part
+
+
+@pytest.mark.offline
+def test_remove_eda_part_preserves_text_between_multiple_blocks() -> None:
+    stdout = (
+        "before\n"
+        "=== Start of EDA part ===\n"
+        "eda one\n"
+        "=== End of EDA part ===\n"
+        "between\n"
+        "=== Start of EDA part ===\n"
+        "eda two\n"
+        "=== End of EDA part ===\n"
+        "after\n"
+    )
+
+    cleaned = remove_eda_part(stdout)
+
+    assert cleaned == "before\n\nbetween\n\nafter\n"


### PR DESCRIPTION
## Description

Match each EDA block independently so normal stdout between multiple blocks is preserved.

## Motivation and Context

The previous greedy match removed text from the first start marker through the last end marker when stdout contained multiple EDA blocks.

Fixes #1459.

## How Has This Been Tested?

- `python -m pytest test/utils/coder/test_data_science_utils.py -q`
- Black (120-character line length) and isort checks for the changed files
- `python -m compileall -q rdagent/components/coder/data_science/utils.py test/utils/coder/test_data_science_utils.py`
- `git diff --check`

The focused regression test passes. The full test suite was not run.

## Types of changes

- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation


<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1465.org.readthedocs.build/en/1465/

<!-- readthedocs-preview RDAgent end -->