### PR TITLE
fix: reject sub-daily factor intervals

### DIFF
--- a/rdagent/components/coder/factor_coder/eva_utils.py
+++ b/rdagent/components/coder/factor_coder/eva_utils.py
@@ -228,15 +228,24 @@ class FactorDatetimeDailyEvaluator(FactorEvaluator):
             return "The source dataframe does not have a datetime index. Please check the implementation.", False
 
         try:
-            pd.to_datetime(gen_df.index.get_level_values("datetime"))
+            datetime_values = pd.DatetimeIndex(pd.to_datetime(gen_df.index.get_level_values("datetime")))
         except Exception:
             return (
                 f"The source dataframe has a datetime index but it is not in the correct format (maybe a regular string or other objects). Please check the implementation.\n The head of the output dataframe is: \n{gen_df.head()}",
                 False,
             )
 
-        time_diff = pd.to_datetime(gen_df.index.get_level_values("datetime")).to_series().diff().dropna().unique()
-        if pd.Timedelta(minutes=1) in time_diff:
+        if datetime_values.hasnans:
+            return (
+                "The source dataframe has missing datetime values. Please check the implementation.",
+                False,
+            )
+
+        unique_datetimes = datetime_values.unique()
+        if unique_datetimes.tz is not None:
+            unique_datetimes = unique_datetimes.tz_localize(None)
+        time_diff = unique_datetimes.sort_values().to_series().diff().dropna()
+        if any(diff < pd.Timedelta(1, unit="D") for diff in time_diff):
             return (
                 "The generated dataframe is not daily. The implementation is definitely wrong. Please check the implementation.",
                 False,

--- a/test/qlib/test_factor_datetime_daily_evaluator.py
+++ b/test/qlib/test_factor_datetime_daily_evaluator.py
@@ -1,0 +1,108 @@
+import pandas as pd
+import pytest
+
+from rdagent.components.coder.factor_coder.eva_utils import (
+    FactorDatetimeDailyEvaluator,
+)
+
+
+def _evaluate_datetimes(datetimes: pd.DatetimeIndex) -> tuple[str, bool]:
+    index = pd.MultiIndex.from_product(
+        [datetimes, ["instrument_1", "instrument_2"]],
+        names=["datetime", "instrument"],
+    )
+
+    return _evaluate_index(index)
+
+
+def _evaluate_index(index: pd.MultiIndex) -> tuple[str, bool]:
+    gen_df = pd.DataFrame({"factor": range(len(index))}, index=index)
+    evaluator = object.__new__(FactorDatetimeDailyEvaluator)
+    evaluator._get_df = lambda _gt_implementation, _implementation: (  # noqa: SLF001
+        None,
+        gen_df,
+    )
+    return evaluator.evaluate(None, None)
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize("freq", ["1min", "s", "30min", "h"])
+def test_datetime_daily_evaluator_rejects_subdaily_frequency(freq: str) -> None:
+    message, is_daily = _evaluate_datetimes(
+        pd.date_range("2024-01-01", periods=3, freq=freq),
+    )
+
+    assert is_daily is False, message
+
+
+@pytest.mark.offline
+def test_datetime_daily_evaluator_allows_daily_multi_instrument_data() -> None:
+    datetimes = pd.date_range("2024-01-01", periods=3, freq="D")
+
+    message, is_daily = _evaluate_datetimes(datetimes)
+
+    assert is_daily is True, message
+
+
+@pytest.mark.offline
+def test_datetime_daily_evaluator_rejects_mixed_daily_and_subdaily_frequency() -> None:
+    datetimes = pd.DatetimeIndex(
+        [
+            "2024-01-01 00:00:00",
+            "2024-01-02 00:00:00",
+            "2024-01-02 01:00:00",
+        ],
+    )
+
+    message, is_daily = _evaluate_datetimes(datetimes)
+
+    assert is_daily is False, message
+
+
+@pytest.mark.offline
+def test_datetime_daily_evaluator_allows_daily_calendar_gaps() -> None:
+    datetimes = pd.DatetimeIndex(["2024-01-05", "2024-01-08", "2024-01-09"])
+
+    message, is_daily = _evaluate_datetimes(datetimes)
+
+    assert is_daily is True, message
+
+
+@pytest.mark.offline
+def test_datetime_daily_evaluator_allows_daily_data_across_dst() -> None:
+    datetimes = pd.date_range(
+        "2024-03-09",
+        periods=3,
+        freq="D",
+        tz="America/New_York",
+    )
+
+    message, is_daily = _evaluate_datetimes(datetimes)
+
+    assert is_daily is True, message
+
+
+@pytest.mark.offline
+def test_datetime_daily_evaluator_rejects_subdaily_instrument_first_index() -> None:
+    index = pd.MultiIndex.from_tuples(
+        [
+            ("instrument_1", "2024-01-01 00:00:00"),
+            ("instrument_1", "2024-01-02 00:00:00"),
+            ("instrument_2", "2024-01-01 23:00:00"),
+            ("instrument_2", "2024-01-02 23:00:00"),
+        ],
+        names=["instrument", "datetime"],
+    )
+
+    message, is_daily = _evaluate_index(index)
+
+    assert is_daily is False, message
+
+
+@pytest.mark.offline
+def test_datetime_daily_evaluator_rejects_missing_datetimes() -> None:
+    message, is_daily = _evaluate_datetimes(
+        pd.DatetimeIndex(["2024-01-01", pd.NaT]),
+    )
+
+    assert is_daily is False, message


### PR DESCRIPTION
## Description

Reject sub-daily datetime intervals when checking whether generated factor data is daily.

## Motivation and Context

The evaluator previously rejected only one-minute intervals and classified other sub-daily data, such as hourly data, as daily. The check now rejects any interval shorter than one day while still allowing calendar gaps.

Fixes #1453.

## How Has This Been Tested?

- `python -m pytest test/qlib/test_factor_datetime_daily_evaluator.py -q`
- `python -m compileall -q rdagent/components/coder/factor_coder/eva_utils.py test/qlib/test_factor_datetime_daily_evaluator.py`
- `git diff --check`

The focused regression tests cover sub-daily intervals, daily data, calendar gaps, time zones, index ordering, and missing values. The full test suite was not run.

## Types of changes

- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation


<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1466.org.readthedocs.build/en/1466/

<!-- readthedocs-preview RDAgent end -->