### PR TITLE
fix: harden log server web boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,65 @@ rdagent server_ui --port 19899
 
 After that, open `http://127.0.0.1:19899` in your browser.
 
+##### Web UI security and remote access
+
+The Flask backend listens on `127.0.0.1` by default. This keeps its process-control, upload, and trace APIs accessible only from the local machine. No authentication token is required while the server is bound to localhost.
+
+To access the Web UI from another machine, explicitly bind it to a non-local address and configure an authentication token:
+
+```sh
+export UI_SERVER_AUTH_TOKEN='<a-long-random-token>'
+rdagent server_ui --port 19899 --host 0.0.0.0
+```
+
+Then open the following URL once to establish an authenticated browser session:
+
+```text
+http://<server-host>:19899/?token=<a-long-random-token>
+```
+
+The server removes the token from the address bar by redirecting to `/` and stores it in an HTTP-only, same-site cookie. API clients can instead send it in the request header:
+
+```text
+Authorization: Bearer <a-long-random-token>
+```
+
+The server refuses to bind to a non-local address unless `UI_SERVER_AUTH_TOKEN` is set. When exposing it outside a trusted development machine, put it behind an HTTPS reverse proxy and avoid recording token-bearing query strings in proxy logs. The `--host` option controls the address when the server is started through the CLI; `UI_SERVER_HOST` is the corresponding default for direct use of the backend entry point.
+
+Cross-origin browser access is disabled by default. If the frontend and backend are served from different origins, configure an explicit JSON allowlist rather than enabling every origin:
+
+```sh
+export UI_CORS_ALLOWED_ORIGINS='["https://ui.example.com"]'
+```
+
+##### Web UI storage and compatibility settings
+
+The Flask backend uses the following environment variables. Uploaded input files are deliberately kept outside the trace directory so that they cannot be discovered and deserialized as persisted traces.
+
+| Environment variable | Default | Description |
+| --- | --- | --- |
+| `UI_STATIC_PATH` | `./git_ignore_folder/static` | Directory containing the built Web UI assets. |
+| `UI_TRACE_FOLDER` | `./git_ignore_folder/traces` | Directory containing generated trace data and process logs. |
+| `UI_UPLOAD_FOLDER` | `./git_ignore_folder/uploads` | Isolated directory for uploaded input files. Mount, back up, and clean it separately from the trace directory. |
+| `UI_SERVER_HOST` | `127.0.0.1` | Default host used by the backend entry point. Use `server_ui --host` when starting it through the CLI. |
+| `UI_SERVER_AUTH_TOKEN` | empty | Bearer/cookie authentication token. Required for any non-localhost binding. |
+| `UI_CORS_ALLOWED_ORIGINS` | `[]` | JSON list of allowed browser origins. CORS is disabled when the list is empty. |
+| `UI_MAX_UPLOAD_MB` | `20` | Maximum size in MiB of an entire HTTP request, including all uploaded files and form data. |
+| `UI_LOAD_LEGACY_PICKLE_TRACES` | `false` | Whether to deserialize persisted pickle traces when the server starts. Enable only for a fully trusted trace directory. |
+
+Uploads whose filenames end in `.dill`, `.pickle`, `.pkl`, `.py`, `.pyc`, or `.pyo` are rejected. Existing workflows that use these formats as uploaded inputs must convert them to a non-executable data format or provide them through another trusted mechanism.
+
+Legacy pickle trace loading is disabled by default because pickle deserialization can execute code. Consequently, after a server restart, an existing trace may still appear in the history list but its saved messages will not be loaded into the Web UI. If compatibility with trusted historical traces is required, opt in explicitly:
+
+```sh
+export UI_LOAD_LEGACY_PICKLE_TRACES=true
+rdagent server_ui --port 19899
+```
+
+Only enable this setting when every file under `UI_TRACE_FOLDER` is trusted and the directory is not writable by untrusted users or services.
+
+Data-science trace share links no longer accept a URL-controlled `log_folder`. A link can preserve the selected trace, but the recipient must have the corresponding log folder configured or select it in the UI.
+
 #### Common Notes
 
 Port `19899` is used in the examples above. Before starting either UI, check whether this port is already occupied. If it is, please change it to another available port.

--- a/docs/ui.rst
+++ b/docs/ui.rst
@@ -8,7 +8,7 @@ Introduction
 
 RD-Agent will generate some logs during the R&D process. These logs are very useful for debugging and understanding the R&D process. However, just viewing the terminal log is not intuitive enough. RD-Agent provides a web app as UI to visualize the R&D process. You can easily view the R&D process and understand the R&D process better.
 
-A Quick Demo
+Streamlit UI
 ============
 
 Start Web App
@@ -47,3 +47,142 @@ Use Web App
     - Next Loop: Show one success **R&D Loop**.
     - One Evolving: Show one **evolving** step of **development** part.
     - refresh logs: clear shown logs.
+
+
+Flask Web UI
+============
+
+RD-Agent also provides a separate frontend in ``web/`` backed by the Flask log
+server started with ``rdagent server_ui``. This UI provides real-time trace,
+upload, process-control, and user-interaction APIs.
+
+Build and start
+---------------
+
+Install the frontend dependencies and build the static assets:
+
+.. code-block:: bash
+
+    cd web
+    npm install
+    npm run build:flask
+    cd ..
+
+The generated assets are served from ``./git_ignore_folder/static`` by default.
+Set ``UI_STATIC_PATH`` before starting the server to use another directory.
+
+Start the server locally:
+
+.. code-block:: bash
+
+    rdagent server_ui --port 19899
+
+Then open ``http://127.0.0.1:19899``. The server listens on localhost by
+default, so its process-control, upload, and trace APIs are not exposed to
+other machines.
+
+Remote access and authentication
+--------------------------------
+
+To access the Flask Web UI remotely, explicitly select a non-local address and
+configure a long, random authentication token:
+
+.. code-block:: bash
+
+    export UI_SERVER_AUTH_TOKEN='<a-long-random-token>'
+    rdagent server_ui --port 19899 --host 0.0.0.0
+
+The server refuses to bind to a non-local address unless
+``UI_SERVER_AUTH_TOKEN`` is set. Open the following URL once to establish an
+authenticated browser session:
+
+.. code-block:: text
+
+    http://<server-host>:19899/?token=<a-long-random-token>
+
+The server redirects to ``/`` after storing the token in an HTTP-only,
+same-site cookie. API clients can supply the same token without using a cookie:
+
+.. code-block:: text
+
+    Authorization: Bearer <a-long-random-token>
+
+Put remotely accessible deployments behind an HTTPS reverse proxy. Avoid
+recording the initial token-bearing URL in proxy logs or sharing it through an
+untrusted channel. When the server is started through the CLI, ``--host``
+controls the listening address; ``UI_SERVER_HOST`` is the corresponding default
+when invoking the backend entry point directly.
+
+CORS is disabled by default. If a browser frontend is hosted on another origin,
+configure an explicit JSON allowlist:
+
+.. code-block:: bash
+
+    export UI_CORS_ALLOWED_ORIGINS='["https://ui.example.com"]'
+
+Configuration
+-------------
+
+The Flask Web UI supports the following environment variables:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 25 70
+
+   * - Environment variable
+     - Default
+     - Description
+   * - ``UI_STATIC_PATH``
+     - ``./git_ignore_folder/static``
+     - Directory containing the built Web UI assets.
+   * - ``UI_TRACE_FOLDER``
+     - ``./git_ignore_folder/traces``
+     - Directory containing generated trace data and process logs.
+   * - ``UI_UPLOAD_FOLDER``
+     - ``./git_ignore_folder/uploads``
+     - Isolated directory for uploaded inputs. Mount, back up, and clean it
+       separately from the trace directory.
+   * - ``UI_SERVER_HOST``
+     - ``127.0.0.1``
+     - Default host used by the backend entry point. Use ``server_ui --host``
+       when starting the server through the CLI.
+   * - ``UI_SERVER_AUTH_TOKEN``
+     - empty
+     - Bearer/cookie authentication token. Required for non-localhost bindings.
+   * - ``UI_CORS_ALLOWED_ORIGINS``
+     - ``[]``
+     - JSON list of allowed browser origins. CORS is disabled when empty.
+   * - ``UI_MAX_UPLOAD_MB``
+     - ``20``
+     - Maximum size in MiB of the complete HTTP request, including all files and
+       form data.
+   * - ``UI_LOAD_LEGACY_PICKLE_TRACES``
+     - ``false``
+     - Whether to deserialize persisted pickle traces at startup. Enable only
+       for a fully trusted trace directory.
+
+Upload and trace safety
+-----------------------
+
+Uploaded input files are stored outside ``UI_TRACE_FOLDER`` so they cannot be
+discovered and deserialized as persisted traces. Uploads ending in ``.dill``,
+``.pickle``, ``.pkl``, ``.py``, ``.pyc``, or ``.pyo`` are rejected. Workflows
+using these formats as uploaded inputs must convert them to a non-executable
+data format or provide them through another trusted mechanism.
+
+Legacy pickle trace loading is disabled by default because deserializing a
+pickle can execute code. After a restart, a historical trace may still appear
+in the history list while its saved messages remain unloaded. To browse trusted
+historical traces, opt in explicitly:
+
+.. code-block:: bash
+
+    export UI_LOAD_LEGACY_PICKLE_TRACES=true
+    rdagent server_ui --port 19899
+
+Only enable this setting when every file under ``UI_TRACE_FOLDER`` is trusted
+and the directory is not writable by untrusted users or services.
+
+Data-science trace share links no longer accept a URL-controlled ``log_folder``.
+A link can preserve the selected trace, but the recipient must configure or
+select the corresponding log folder in the UI.

--- a/rdagent/app/cli.py
+++ b/rdagent/app/cli.py
@@ -62,13 +62,13 @@ def ui(port=19899, log_dir="", debug: bool = False, data_science: bool = False):
         subprocess.run(cmds)
 
 
-def server_ui(port=19899):
+def server_ui(port: int = 19899, host: str = "127.0.0.1") -> None:
     """
     start the Flask log server in real time
     """
     from rdagent.log.server.app import main as log_server_main
 
-    log_server_main(port=port)
+    log_server_main(port=port, host=host)
 
 
 def ds_user_interact(port=19900):

--- a/rdagent/log/server/app.py
+++ b/rdagent/log/server/app.py
@@ -1,3 +1,4 @@
+import hmac
 import logging
 import os
 import random
@@ -11,20 +12,45 @@ from queue import Empty
 
 import randomname
 import typer
-from flask import Flask, jsonify, request, send_file, send_from_directory
+from flask import Flask, Response, jsonify, make_response, redirect, request, send_file, send_from_directory, url_for
 from flask_cors import CORS
-from werkzeug.utils import secure_filename
-
+from rdagent.log.server.security import (
+    SCENARIO_TARGETS,
+    parse_competition,
+    resolve_within,
+    validate_scenario,
+    validate_upload_filename,
+)
 from rdagent.log.storage import FileStorage
 from rdagent.log.ui.conf import UI_SETTING
 from rdagent.log.ui.storage import WebStorage
+from werkzeug.utils import secure_filename
 
 app = Flask(__name__, static_folder=str(Path(UI_SETTING.static_path).resolve()))
-CORS(app)
+if UI_SETTING.cors_allowed_origins:
+    CORS(app, origins=UI_SETTING.cors_allowed_origins, supports_credentials=True)
 app.config["UI_SERVER_PORT"] = 19899
+app.config["MAX_CONTENT_LENGTH"] = UI_SETTING.max_upload_mb * 1024 * 1024
+app.config["AUTH_TOKEN"] = UI_SETTING.server_auth_token
 
 _YELLOW = "\033[33m"
 _RESET = "\033[0m"
+
+_PUBLIC_ENDPOINTS = {"favicon", "index", "server_static_files", "static"}
+
+
+@app.before_request
+def _require_authentication() -> Response | tuple[Response, int] | None:
+    token = app.config.get("AUTH_TOKEN", "")
+    if not token or request.method == "OPTIONS" or request.endpoint in _PUBLIC_ENDPOINTS:
+        return None
+
+    authorization = request.headers.get("Authorization", "")
+    header_token = authorization.removeprefix("Bearer ") if authorization.startswith("Bearer ") else ""
+    provided_token = header_token or request.cookies.get("rdagent_auth", "")
+    if not provided_token or not hmac.compare_digest(provided_token, token):
+        return jsonify({"error": "Authentication required"}), 401
+    return None
 
 
 class _YellowWarningFormatter(logging.Formatter):
@@ -169,7 +195,8 @@ class RDAgentTask:
 
 
 rdagent_processes: dict[str, RDAgentTask] = {}
-log_folder_path = Path(UI_SETTING.trace_folder).absolute()
+log_folder_path = Path(UI_SETTING.trace_folder).resolve()
+upload_folder_path = Path(UI_SETTING.upload_folder).resolve()
 
 
 def _drain_user_requests_into_messages(task: RDAgentTask) -> None:
@@ -386,7 +413,10 @@ def list_traces():
 def upload_file():
     # 获取请求体中的字段
     global rdagent_processes
-    scenario = request.form.get("scenario")
+    try:
+        scenario = validate_scenario(request.form.get("scenario"))
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
     files = request.files.getlist("files")
     competition = request.form.get("competition")
     loop_n = request.form.get("loops")
@@ -394,73 +424,68 @@ def upload_file():
 
     # scenario = "Data Science Loop"
     if scenario == "Data Science":
-        competition = competition[10:]  # Eg. MLE-Bench:aerial-cactus-competition
+        try:
+            competition = parse_competition(competition)
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
         trace_name = f"{competition}-{randomname.get_name()}"
     else:
         trace_name = randomname.get_name()
-    trace_files_path = log_folder_path / "uploads" / scenario / trace_name
-
-    log_trace_path = (log_folder_path / scenario / trace_name).absolute()
-    stdout_path = log_folder_path / scenario / f"{trace_name}.log"
+    try:
+        trace_files_path = resolve_within(upload_folder_path, scenario, trace_name)
+        log_trace_path = resolve_within(log_folder_path, scenario, trace_name)
+        stdout_path = resolve_within(log_folder_path, scenario, f"{trace_name}.log")
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
     if not stdout_path.exists():
         stdout_path.parent.mkdir(parents=True, exist_ok=True)
 
     # save files
     for file in files:
         if file:
-            p = (log_folder_path / "uploads" / scenario / trace_name).resolve()
-            sanitized_filename = secure_filename(file.filename)  # Sanitize filename
-            target_path = (p / sanitized_filename).resolve()  # Normalize target path
-            # Ensure target_path is within the allowed base directory
-            if os.path.commonpath([str(target_path), str(p)]) == str(p) and target_path.is_file() == False:
-                if not p.exists():
-                    p.mkdir(parents=True, exist_ok=True)
-                file.save(target_path)
-            else:
-                return jsonify({"error": "Invalid file path"}), 400
+            try:
+                sanitized_filename = validate_upload_filename(secure_filename(file.filename or ""))
+                target_path = resolve_within(trace_files_path, sanitized_filename)
+            except ValueError as exc:
+                return jsonify({"error": str(exc)}), 400
+            if target_path.exists():
+                return jsonify({"error": "Upload file already exists"}), 409
+            trace_files_path.mkdir(parents=True, exist_ok=True)
+            file.save(target_path)
 
-    target_name = None
+    target_name = SCENARIO_TARGETS[scenario]
     kwargs = {}
     loop_n_val = int(loop_n) if loop_n else None
     all_duration_val = f"{all_duration}h" if all_duration else None
 
     if scenario == "Finance Data Building":
-        target_name = "fin_factor"
         kwargs = {
             "loop_n": loop_n_val,
             "all_duration": all_duration_val,
             "base_features_path": str(trace_files_path),
         }
     if scenario == "Finance Model Implementation":
-        target_name = "fin_model"
         kwargs = {
             "loop_n": loop_n_val,
             "all_duration": all_duration_val,
             "base_features_path": str(trace_files_path),
         }
     if scenario == "Finance Whole Pipeline":
-        target_name = "fin_quant"
         kwargs = {
             "loop_n": loop_n_val,
             "all_duration": all_duration_val,
             "base_features_path": str(trace_files_path),
         }
     if scenario == "Finance Data Building (Reports)":
-        target_name = "fin_factor_report"
         kwargs = {"report_folder": str(trace_files_path), "all_duration": all_duration_val}
     if scenario == "General Model Implementation":
         if len(files) == 0:  # files is one link
-            rfp = request.form.get("files")[0]
+            rfp = request.form.get("files", "")
         else:  # one file is uploaded
-            rfp = str(trace_files_path / files[0].filename)
-        target_name = "general_model"
+            rfp = str(resolve_within(trace_files_path, validate_upload_filename(secure_filename(files[0].filename))))
         kwargs = {"report_file_path": rfp}
     if scenario == "Data Science":
-        target_name = "data_science"
         kwargs = {"competition": competition, "loop_n": loop_n_val, "timeout": all_duration_val}
-
-    if target_name is None:
-        return jsonify({"error": "Unknown scenario"}), 400
 
     app.logger.info(f"Started process for {log_trace_path} with target: {target_name}, kwargs: {kwargs}")
     task = RDAgentTask(
@@ -578,8 +603,12 @@ def test():
 
 @app.route("/", methods=["GET"])
 def index():
-    # return 'Hello, World!'
-    # return {k: [i["tag"] for i in v] for k, v in msgs_for_frontend.items()}
+    token = app.config.get("AUTH_TOKEN", "")
+    supplied_token = request.args.get("token", "")
+    if token and supplied_token and hmac.compare_digest(supplied_token, token):
+        response = make_response(redirect(url_for("index")))
+        response.set_cookie("rdagent_auth", token, httponly=True, samesite="Strict")
+        return response
     return send_from_directory(app.static_folder, "index.html")
 
 
@@ -588,10 +617,16 @@ def server_static_files(fn):
     return send_from_directory(app.static_folder, _normalize_static_request_path(fn))
 
 
-def main(port: int = 19899):
+def main(port: int = 19899, host: str = UI_SETTING.server_host) -> None:
+    if host not in {"127.0.0.1", "::1", "localhost"} and not app.config.get("AUTH_TOKEN"):
+        raise ValueError("UI_SERVER_AUTH_TOKEN is required when binding the log server beyond localhost")
     app.config["UI_SERVER_PORT"] = port
-    _load_existing_traces(log_folder_path)
-    app.run(debug=False, host="0.0.0.0", port=port)
+    if app.config.get("AUTH_TOKEN"):
+        app.logger.info("Authentication enabled. Open /?token=<UI_SERVER_AUTH_TOKEN> to establish a secure session.")
+    if UI_SETTING.load_legacy_pickle_traces:
+        app.logger.warning("Loading legacy pickle traces. Only enable this for fully trusted trace directories.")
+        _load_existing_traces(log_folder_path)
+    app.run(debug=False, host=host, port=port)
 
 
 if __name__ == "__main__":

--- a/rdagent/log/server/app.py
+++ b/rdagent/log/server/app.py
@@ -426,8 +426,8 @@ def upload_file():
     global rdagent_processes
     try:
         scenario = validate_scenario(request.form.get("scenario"))
-    except ValueError as exc:
-        return jsonify({"error": str(exc)}), 400
+    except ValueError:
+        return jsonify({"error": "Invalid scenario"}), 400
     files = request.files.getlist("files")
     competition = request.form.get("competition")
     loop_n = request.form.get("loops")
@@ -437,8 +437,8 @@ def upload_file():
     if scenario == "Data Science":
         try:
             competition = parse_competition(competition)
-        except ValueError as exc:
-            return jsonify({"error": str(exc)}), 400
+        except ValueError:
+            return jsonify({"error": "Invalid competition"}), 400
         trace_name = f"{competition}-{randomname.get_name()}"
     else:
         trace_name = randomname.get_name()
@@ -446,8 +446,8 @@ def upload_file():
         trace_files_path = resolve_within(upload_folder_path, scenario, trace_name)
         log_trace_path = resolve_within(log_folder_path, scenario, trace_name)
         stdout_path = resolve_within(log_folder_path, scenario, f"{trace_name}.log")
-    except ValueError as exc:
-        return jsonify({"error": str(exc)}), 400
+    except ValueError:
+        return jsonify({"error": "Invalid destination path"}), 400
     if not stdout_path.exists():
         stdout_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -457,8 +457,8 @@ def upload_file():
             try:
                 sanitized_filename = validate_upload_filename(secure_filename(file.filename or ""))
                 target_path = resolve_within(trace_files_path, sanitized_filename)
-            except ValueError as exc:
-                return jsonify({"error": str(exc)}), 400
+            except ValueError:
+                return jsonify({"error": "Invalid upload file"}), 400
             if target_path.exists():
                 return jsonify({"error": "Upload file already exists"}), 409
             trace_files_path.mkdir(parents=True, exist_ok=True)
@@ -558,8 +558,9 @@ def submit_user_interaction_response():
 
     try:
         task.user_response_q.put(payload, block=False)
-    except Exception as e:
-        return jsonify({"error": f"Failed to enqueue user response: {e}"}), 500
+    except Exception:
+        app.logger.exception("Failed to enqueue a user response")
+        return jsonify({"error": "Failed to enqueue user response"}), 500
 
     return jsonify({"status": "success"}), 200
 
@@ -600,8 +601,9 @@ def control_process():
             )
             app.logger.warning(f"Process for {id} has been stopped.")
         return jsonify({"status": "stopped"}), 200
-    except Exception as e:
-        return jsonify({"error": f"Failed to {action} process, {e}"}), 500
+    except Exception:
+        app.logger.exception("Failed to stop process %s", id)
+        return jsonify({"error": "Failed to stop process"}), 500
 
 
 @app.route("/test", methods=["GET"])

--- a/rdagent/log/server/app.py
+++ b/rdagent/log/server/app.py
@@ -12,8 +12,20 @@ from queue import Empty
 
 import randomname
 import typer
-from flask import Flask, Response, jsonify, make_response, redirect, request, send_file, send_from_directory, url_for
+from flask import (
+    Flask,
+    Response,
+    jsonify,
+    make_response,
+    redirect,
+    request,
+    send_file,
+    send_from_directory,
+    url_for,
+)
 from flask_cors import CORS
+from werkzeug.utils import secure_filename
+
 from rdagent.log.server.security import (
     SCENARIO_TARGETS,
     parse_competition,
@@ -24,7 +36,6 @@ from rdagent.log.server.security import (
 from rdagent.log.storage import FileStorage
 from rdagent.log.ui.conf import UI_SETTING
 from rdagent.log.ui.storage import WebStorage
-from werkzeug.utils import secure_filename
 
 app = Flask(__name__, static_folder=str(Path(UI_SETTING.static_path).resolve()))
 if UI_SETTING.cors_allowed_origins:

--- a/rdagent/log/server/debug_app.py
+++ b/rdagent/log/server/debug_app.py
@@ -12,12 +12,11 @@ from pathlib import Path
 import randomname
 import typer
 from flask import Flask, jsonify, request, send_from_directory
-from flask_cors import CORS
 
+from rdagent.log.server.security import parse_competition, resolve_within, validate_scenario
 from rdagent.log.ui.conf import UI_SETTING
 
 app = Flask(__name__, static_folder=UI_SETTING.static_path)
-CORS(app)
 
 rdagent_processes = defaultdict()
 server_port = 19899
@@ -74,7 +73,10 @@ def update_trace():
 def upload_file():
     # 获取请求体中的字段
     global rdagent_processes, server_port, msgs_for_frontend
-    scenario = request.form.get("scenario")
+    try:
+        scenario = validate_scenario(request.form.get("scenario"))
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
     files = request.files.getlist("files")
     competition = request.form.get("competition")
     loop_n = request.form.get("loops")
@@ -83,9 +85,13 @@ def upload_file():
     log_folder_path = Path("/home/bowen/workspace/new_traces").absolute()
 
     if scenario == "Data Science":
-        trace_path = log_folder_path / "o1-preview" / f"{competition[10:]}.1"
+        try:
+            competition = parse_competition(competition)
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+        trace_path = resolve_within(log_folder_path, "o1-preview", f"{competition}.1")
     else:
-        trace_path = log_folder_path / scenario
+        trace_path = resolve_within(log_folder_path, scenario)
     id = f"{scenario}/{randomname.get_name()}"
 
     def read_trace(log_path: Path, t: float = 0.2, id: str = "") -> None:
@@ -167,7 +173,7 @@ def server_static_files(fn):
 def main(port: int = 19899):
     global server_port
     server_port = port
-    app.run(debug=True, host="0.0.0.0", port=port)
+    app.run(debug=True, host="127.0.0.1", port=port)
 
 
 if __name__ == "__main__":

--- a/rdagent/log/server/debug_app.py
+++ b/rdagent/log/server/debug_app.py
@@ -79,8 +79,8 @@ def upload_file():
     global rdagent_processes, server_port, msgs_for_frontend
     try:
         scenario = validate_scenario(request.form.get("scenario"))
-    except ValueError as exc:
-        return jsonify({"error": str(exc)}), 400
+    except ValueError:
+        return jsonify({"error": "Invalid scenario"}), 400
     files = request.files.getlist("files")
     competition = request.form.get("competition")
     loop_n = request.form.get("loops")
@@ -91,8 +91,8 @@ def upload_file():
     if scenario == "Data Science":
         try:
             competition = parse_competition(competition)
-        except ValueError as exc:
-            return jsonify({"error": str(exc)}), 400
+        except ValueError:
+            return jsonify({"error": "Invalid competition"}), 400
         trace_path = resolve_within(log_folder_path, "o1-preview", f"{competition}.1")
     else:
         trace_path = resolve_within(log_folder_path, scenario)
@@ -177,7 +177,7 @@ def server_static_files(fn):
 def main(port: int = 19899):
     global server_port
     server_port = port
-    app.run(debug=True, host="127.0.0.1", port=port)
+    app.run(debug=False, host="127.0.0.1", port=port)
 
 
 if __name__ == "__main__":

--- a/rdagent/log/server/debug_app.py
+++ b/rdagent/log/server/debug_app.py
@@ -13,7 +13,11 @@ import randomname
 import typer
 from flask import Flask, jsonify, request, send_from_directory
 
-from rdagent.log.server.security import parse_competition, resolve_within, validate_scenario
+from rdagent.log.server.security import (
+    parse_competition,
+    resolve_within,
+    validate_scenario,
+)
 from rdagent.log.ui.conf import UI_SETTING
 
 app = Flask(__name__, static_folder=UI_SETTING.static_path)

--- a/rdagent/log/server/security.py
+++ b/rdagent/log/server/security.py
@@ -1,0 +1,55 @@
+import re
+from pathlib import Path
+
+SCENARIO_TARGETS = {
+    "Finance Data Building": "fin_factor",
+    "Finance Model Implementation": "fin_model",
+    "Finance Whole Pipeline": "fin_quant",
+    "Finance Data Building (Reports)": "fin_factor_report",
+    "General Model Implementation": "general_model",
+    "Data Science": "data_science",
+}
+
+_COMPETITION_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,99}$")
+_UNSAFE_UPLOAD_SUFFIXES = {".dill", ".pickle", ".pkl", ".py", ".pyc", ".pyo"}
+_ERR_COMPETITION_PREFIX = "Competition must start with 'MLE-Bench:'"
+_ERR_INVALID_COMPETITION = "Invalid competition name"
+_ERR_INVALID_FILENAME = "Invalid upload filename"
+_ERR_PATH_ESCAPE = "Path escapes the configured root"
+_ERR_UNKNOWN_SCENARIO = "Unknown scenario"
+_ERR_UNSAFE_FILE_TYPE = "Unsafe upload file type"
+
+
+def validate_scenario(value: str | None) -> str:
+    if value not in SCENARIO_TARGETS:
+        raise ValueError(_ERR_UNKNOWN_SCENARIO)
+    return value
+
+
+def parse_competition(value: str | None) -> str:
+    prefix = "MLE-Bench:"
+    if value is None or not value.startswith(prefix):
+        raise ValueError(_ERR_COMPETITION_PREFIX)
+    competition = value[len(prefix) :]
+    if not _COMPETITION_RE.fullmatch(competition):
+        raise ValueError(_ERR_INVALID_COMPETITION)
+    return competition
+
+
+def resolve_within(root: str | Path, *parts: str) -> Path:
+    resolved_root = Path(root).resolve()
+    resolved_path = resolved_root.joinpath(*parts).resolve()
+    try:
+        resolved_path.relative_to(resolved_root)
+    except ValueError as exc:
+        raise ValueError(_ERR_PATH_ESCAPE) from exc
+    return resolved_path
+
+
+def validate_upload_filename(value: str) -> str:
+    filename = Path(value).name
+    if not filename or filename in {".", ".."}:
+        raise ValueError(_ERR_INVALID_FILENAME)
+    if Path(filename).suffix.lower() in _UNSAFE_UPLOAD_SUFFIXES:
+        raise ValueError(_ERR_UNSAFE_FILE_TYPE)
+    return filename

--- a/rdagent/log/ui/conf.py
+++ b/rdagent/log/ui/conf.py
@@ -18,6 +18,18 @@ class UIBasePropSetting(ExtendedBaseSettings):
 
     trace_folder: str = "./git_ignore_folder/traces"
 
+    upload_folder: str = "./git_ignore_folder/uploads"
+
+    server_host: str = "127.0.0.1"
+
+    server_auth_token: str = ""
+
+    cors_allowed_origins: list[str] = []
+
+    max_upload_mb: int = 20
+
+    load_legacy_pickle_traces: bool = False
+
     enable_cache: bool = True
 
 

--- a/rdagent/log/ui/ds_trace.py
+++ b/rdagent/log/ui/ds_trace.py
@@ -1186,10 +1186,7 @@ def get_state_data_range(state_data):
 
 # UI - Main
 if "competition" in state.data:
-    st.title(
-        state.data["competition"]
-        + f" ([share_link](/ds_trace?selection={state.log_path}))"
-    )
+    st.title(state.data["competition"] + f" ([share_link](/ds_trace?selection={state.log_path}))")
     summarize_win()
     min_id, max_id = get_state_data_range(state.data)
     if max_id > min_id:

--- a/rdagent/log/ui/ds_trace.py
+++ b/rdagent/log/ui/ds_trace.py
@@ -1129,17 +1129,13 @@ with st.sidebar:
         elif day_srv == "srv3":
             state.log_folders = [re.sub(r"log\.srv\d*", "log.srv3", folder) for folder in state.log_folders]
 
-    if "log_folder" in st.query_params:
-        state.log_folder = Path(st.query_params["log_folder"])
-        state.log_folders = [str(state.log_folder)]
-    else:
-        state.log_folder = Path(
-            st.radio(
-                f"Select :blue[**one log folder**]",
-                state.log_folders,
-                format_func=lambda x: x[x.rfind("amlt") + 5 :].split("/")[0] if "amlt" in x else x,
-            )
+    state.log_folder = Path(
+        st.radio(
+            f"Select :blue[**one log folder**]",
+            state.log_folders,
+            format_func=lambda x: x[x.rfind("amlt") + 5 :].split("/")[0] if "amlt" in x else x,
         )
+    )
     if not state.log_folder.exists():
         st.warning(f"Path {state.log_folder} does not exist!")
     else:
@@ -1192,7 +1188,7 @@ def get_state_data_range(state_data):
 if "competition" in state.data:
     st.title(
         state.data["competition"]
-        + f" ([share_link](/ds_trace?log_folder={state.log_folder}&selection={state.log_path}))"
+        + f" ([share_link](/ds_trace?selection={state.log_path}))"
     )
     summarize_win()
     min_id, max_id = get_state_data_range(state.data)

--- a/rdagent/log/ui/storage.py
+++ b/rdagent/log/ui/storage.py
@@ -46,6 +46,8 @@ class WebStorage(Storage):
             else:
                 self.msgs.append(data)
             headers = {"Content-Type": "application/json"}
+            if UI_SETTING.server_auth_token:
+                headers["Authorization"] = f"Bearer {UI_SETTING.server_auth_token}"
             resp = requests.post(f"{self.url}/receive", json=data, headers=headers, timeout=1)
             return f"{resp.status_code} {resp.text}"
         except (requests.ConnectionError, requests.Timeout) as e:

--- a/test/log/server/test_security.py
+++ b/test/log/server/test_security.py
@@ -5,12 +5,18 @@ from pathlib import Path
 import pytest
 
 import rdagent.log.server.app as server
+import rdagent.log.ui.storage as web_storage
 from rdagent.log.server.security import (
     parse_competition,
     resolve_within,
     validate_scenario,
     validate_upload_filename,
 )
+
+
+class _Response:
+    status_code = HTTPStatus.OK
+    text = "ok"
 
 
 @pytest.mark.offline
@@ -50,6 +56,38 @@ def test_log_server_requires_authentication_when_configured(monkeypatch: pytest.
     assert client.get("/traces").status_code == HTTPStatus.UNAUTHORIZED
     response = client.get("/traces", headers={"Authorization": "Bearer secret-token"})
     assert response.status_code == HTTPStatus.OK
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize(
+    ("token", "expected_authorization"),
+    [("secret-token", "Bearer secret-token"), ("", None)],
+)
+def test_web_storage_authenticates_internal_receive_requests(
+    monkeypatch: pytest.MonkeyPatch,
+    token: str,
+    expected_authorization: str | None,
+) -> None:
+    request_headers: dict[str, str] = {}
+
+    def fake_post(url: str, *, json: object, headers: dict[str, str], timeout: int) -> _Response:
+        assert url == "http://localhost:19899/receive"
+        assert json == {"id": "trace", "msg": {"tag": "test"}}
+        assert timeout == 1
+        request_headers.update(headers)
+        return _Response()
+
+    monkeypatch.setattr(web_storage.UI_SETTING, "server_auth_token", token)
+    monkeypatch.setattr(web_storage.requests, "post", fake_post)
+    storage = web_storage.WebStorage(port=19899, path="trace")
+    monkeypatch.setattr(
+        storage,
+        "_obj_to_json",
+        lambda **_kwargs: {"id": "trace", "msg": {"tag": "test"}},
+    )
+
+    assert storage.log("message", "test") == "200 ok"
+    assert request_headers.get("Authorization") == expected_authorization
 
 
 @pytest.mark.offline

--- a/test/log/server/test_security.py
+++ b/test/log/server/test_security.py
@@ -1,0 +1,80 @@
+from http import HTTPStatus
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+
+import rdagent.log.server.app as server
+from rdagent.log.server.security import (
+    parse_competition,
+    resolve_within,
+    validate_scenario,
+    validate_upload_filename,
+)
+
+
+@pytest.mark.offline
+def test_validate_scenario_rejects_path_traversal() -> None:
+    with pytest.raises(ValueError, match="Unknown scenario"):
+        validate_scenario("../Data Science")
+
+
+@pytest.mark.offline
+def test_parse_competition_accepts_only_mle_bench_slug() -> None:
+    assert parse_competition("MLE-Bench:aerial-cactus-identification") == "aerial-cactus-identification"
+    for value in (None, "aerial-cactus", "MLE-Bench:../../tmp", "MLE-Bench:a;id"):
+        with pytest.raises(ValueError, match=r"Competition|Invalid"):
+            parse_competition(value)
+
+
+@pytest.mark.offline
+def test_resolve_within_rejects_escape(tmp_path: Path) -> None:
+    assert resolve_within(tmp_path, "scenario", "trace").is_relative_to(tmp_path)
+    with pytest.raises(ValueError, match="escapes"):
+        resolve_within(tmp_path, "..", "outside")
+
+
+@pytest.mark.offline
+def test_upload_filename_rejects_executable_formats() -> None:
+    assert validate_upload_filename("report.pdf") == "report.pdf"
+    for filename in ("payload.pkl", "payload.PICKLE", "script.py", ""):
+        with pytest.raises(ValueError, match=r"upload|file type"):
+            validate_upload_filename(filename)
+
+
+@pytest.mark.offline
+def test_log_server_requires_authentication_when_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(server.app.config, "AUTH_TOKEN", "secret-token")
+    client = server.app.test_client()
+
+    assert client.get("/traces").status_code == HTTPStatus.UNAUTHORIZED
+    response = client.get("/traces", headers={"Authorization": "Bearer secret-token"})
+    assert response.status_code == HTTPStatus.OK
+
+
+@pytest.mark.offline
+def test_upload_rejects_unknown_scenario_before_writing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setitem(server.app.config, "AUTH_TOKEN", "")
+    monkeypatch.setattr(server, "upload_folder_path", tmp_path / "uploads")
+    client = server.app.test_client()
+
+    response = client.post("/upload", data={"scenario": "../Data Science"})
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert not tmp_path.exists() or not any(tmp_path.iterdir())
+
+
+@pytest.mark.offline
+def test_upload_rejects_pickle_before_starting_task(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setitem(server.app.config, "AUTH_TOKEN", "")
+    monkeypatch.setattr(server, "upload_folder_path", tmp_path / "uploads")
+    monkeypatch.setattr(server, "log_folder_path", tmp_path / "traces")
+    client = server.app.test_client()
+
+    response = client.post(
+        "/upload",
+        data={"scenario": "Finance Data Building", "files": (BytesIO(b"payload"), "payload.pkl")},
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert not (tmp_path / "uploads").exists()


### PR DESCRIPTION
## Summary

- validate `scenario`, MLE-Bench competition slugs, upload filenames, and resolved paths before filesystem writes
- isolate uploads from the trace directory and reject executable pickle/script upload formats
- default the Flask and debug servers to localhost; require `UI_SERVER_AUTH_TOKEN` for non-localhost binding
- make CORS opt-in with an explicit origin allowlist and cap request size
- disable legacy pickle trace loading on startup by default
- remove URL-controlled `log_folder` selection from the DS trace viewer

## Security impact

This breaks the unauthenticated path-traversal-to-pickle-deserialization chain reported against the log server and reduces the default network attack surface. Legacy pickle loading remains available only through the explicit `UI_LOAD_LEGACY_PICKLE_TRACES` setting for trusted directories.

## Test plan

- `uv run pytest test/log/server/test_security.py -q`
- 7 tests pass, covering path containment, scenario/competition validation, unsafe upload rejection, authentication, and rejection before filesystem writes.


<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1468.org.readthedocs.build/en/1468/

<!-- readthedocs-preview RDAgent end -->