### PR TITLE
fix: harden execution and archive handling

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -83,3 +83,56 @@ File Naming Convention
      - The configuration for the module, app, and project.
 
 .. <!-- TODO: renaming files -->
+
+
+Security boundaries for generated code and artifacts
+====================================================
+
+RD-Agent executes generated code and processes files produced by external
+tools. Treat filenames, archive members, subprocess output, competition names,
+and environment names as untrusted input even when the surrounding workflow is
+started by a trusted operator.
+
+Workspace file operations
+-------------------------
+
+Use :meth:`FBWorkspace.inject_files <rdagent.core.experiment.FBWorkspace.inject_files>`
+and :meth:`FBWorkspace.remove_files <rdagent.core.experiment.FBWorkspace.remove_files>`
+for files owned by an experiment workspace. These methods accept relative paths
+inside ``workspace_path``. Parent traversal, absolute paths, and paths that
+escape through a symbolic link are rejected before a file is written or
+deleted.
+
+Do not construct an unchecked path from a generated filename and then call
+``write_text()``, ``unlink()``, or another filesystem operation directly. New
+workspace APIs should apply the same resolved-path containment rule to every
+write and delete branch.
+
+Archive extraction
+------------------
+
+Use ``rdagent.utils.archive.safe_extract_zip`` and
+``rdagent.utils.archive.safe_extract_tar`` for archives that may contain
+externally supplied entries. The helpers reject:
+
+* absolute and parent-traversal member paths;
+* symbolic links and hard links;
+* device nodes and other special file types; and
+* archives containing more than 10,000 members by default.
+
+Avoid ``ZipFile.extractall()`` and ``TarFile.extractall()`` in these paths. If a
+workflow legitimately needs links, special files, or a larger archive, handle
+that input in a separately reviewed trusted-data path rather than weakening the
+shared helpers.
+
+Commands and parsed process output
+----------------------------------
+
+Pass subprocess arguments as a list with ``shell=False`` whenever any argument
+can vary. Conda environment names are limited to letters, digits, ``_``, ``-``,
+and ``.``, and Python versions must be numeric dotted versions. Kaggle
+competition identifiers use the corresponding competition-slug validator.
+
+Never use ``eval()`` to parse subprocess or container output. Score output must
+be finite numeric JSON. Legacy Python dictionary-shaped training metrics may be
+parsed with ``ast.literal_eval()`` only when JSON cannot be used.

--- a/rdagent/components/coder/finetune/unified_validator.py
+++ b/rdagent/components/coder/finetune/unified_validator.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set
 
 import yaml
+
 from rdagent.components.coder.finetune.conf import (
     FT_DEBUG_YAML_FILE_NAME,
     FT_TEST_PARAMS_FILE_NAME,

--- a/rdagent/components/coder/finetune/unified_validator.py
+++ b/rdagent/components/coder/finetune/unified_validator.py
@@ -6,6 +6,7 @@ Two-step validation:
 2. Micro-batch testing - Runtime validation with small dataset
 """
 
+import ast
 import json
 import re
 import time
@@ -14,7 +15,6 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set
 
 import yaml
-
 from rdagent.components.coder.finetune.conf import (
     FT_DEBUG_YAML_FILE_NAME,
     FT_TEST_PARAMS_FILE_NAME,
@@ -226,10 +226,10 @@ class LLMConfigValidator:
                 result["num_epochs"] = int(num_epochs.group(1).replace(",", ""))
 
             # Extract final metrics (JSON format from trainer output)
-            final_metrics = re.search(r"\{'train_runtime':[^}]+\}", stdout)
+            final_metrics = re.search(r"\{[\"']train_runtime[\"']:[^}]+\}", stdout)
             if final_metrics:
                 try:
-                    metrics = eval(final_metrics.group(0))  # Safe: only numbers and strings
+                    metrics = ast.literal_eval(final_metrics.group(0))
                     result["final_metrics"] = {
                         "train_loss": metrics.get("train_loss"),
                         "train_runtime": metrics.get("train_runtime"),

--- a/rdagent/core/experiment.py
+++ b/rdagent/core/experiment.py
@@ -220,16 +220,26 @@ class FBWorkspace(Workspace):
 
     DEL_KEY = "__DEL__"
 
-    def _resolve_workspace_path(self, file_name: str) -> Path:
+    def _resolve_workspace_path(self, file_name: str, *, follow_leaf_symlink: bool = True) -> Path:
         """Resolve a caller-provided file name without allowing workspace escape."""
+        relative_path = Path(file_name)
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            message = f"File path must be relative and contained in the workspace: {file_name}"
+            raise ValueError(message)
+
         workspace_root = self.workspace_path.resolve()
-        target_file_path = (workspace_root / file_name).resolve()
+        target_file_path = workspace_root / relative_path
+        resolved_path = (
+            target_file_path.resolve()
+            if follow_leaf_symlink
+            else target_file_path.parent.resolve() / target_file_path.name
+        )
         try:
-            target_file_path.relative_to(workspace_root)
+            resolved_path.relative_to(workspace_root)
         except ValueError as exc:
             message = f"File path escapes workspace: {file_name}"
             raise ValueError(message) from exc
-        return target_file_path
+        return resolved_path if follow_leaf_symlink else target_file_path
 
     def inject_files(self, **files: str) -> None:
         """
@@ -243,12 +253,13 @@ class FBWorkspace(Workspace):
         """
         self.prepare()
         for k, v in files.items():
-            target_file_path = self._resolve_workspace_path(k)
             if v == self.DEL_KEY:  # Use self.DEL_KEY to access the class variable
-                if target_file_path.exists():
+                target_file_path = self._resolve_workspace_path(k, follow_leaf_symlink=False)
+                if target_file_path.exists() or target_file_path.is_symlink():
                     target_file_path.unlink()  # Unlink the file if it exists
                 self.file_dict.pop(k, None)  # Safely remove the key from file_dict
             else:
+                target_file_path = self._resolve_workspace_path(k)
                 self.file_dict[k] = v
                 target_file_path.parent.mkdir(parents=True, exist_ok=True)
                 target_file_path.write_text(v)
@@ -260,8 +271,8 @@ class FBWorkspace(Workspace):
         if isinstance(file_names, str):
             file_names = [file_names]
         for file_name in file_names:
-            target_file_path = self._resolve_workspace_path(file_name)
-            if target_file_path.exists():
+            target_file_path = self._resolve_workspace_path(file_name, follow_leaf_symlink=False)
+            if target_file_path.exists() or target_file_path.is_symlink():
                 target_file_path.unlink()  # Unlink the file if it exists
             self.file_dict.pop(file_name, None)  # Safely remove the key from file_dict
 

--- a/rdagent/core/experiment.py
+++ b/rdagent/core/experiment.py
@@ -220,6 +220,17 @@ class FBWorkspace(Workspace):
 
     DEL_KEY = "__DEL__"
 
+    def _resolve_workspace_path(self, file_name: str) -> Path:
+        """Resolve a caller-provided file name without allowing workspace escape."""
+        workspace_root = self.workspace_path.resolve()
+        target_file_path = (workspace_root / file_name).resolve()
+        try:
+            target_file_path.relative_to(workspace_root)
+        except ValueError as exc:
+            message = f"File path escapes workspace: {file_name}"
+            raise ValueError(message) from exc
+        return target_file_path
+
     def inject_files(self, **files: str) -> None:
         """
         Inject the code into the folder.
@@ -232,7 +243,7 @@ class FBWorkspace(Workspace):
         """
         self.prepare()
         for k, v in files.items():
-            target_file_path = self.workspace_path / k  # Define target_file_path before using it
+            target_file_path = self._resolve_workspace_path(k)
             if v == self.DEL_KEY:  # Use self.DEL_KEY to access the class variable
                 if target_file_path.exists():
                     target_file_path.unlink()  # Unlink the file if it exists
@@ -249,7 +260,7 @@ class FBWorkspace(Workspace):
         if isinstance(file_names, str):
             file_names = [file_names]
         for file_name in file_names:
-            target_file_path = self.workspace_path / file_name
+            target_file_path = self._resolve_workspace_path(file_name)
             if target_file_path.exists():
                 target_file_path.unlink()  # Unlink the file if it exists
             self.file_dict.pop(file_name, None)  # Safely remove the key from file_dict

--- a/rdagent/scenarios/data_science/proposal/exp_gen/select/prompts.yaml
+++ b/rdagent/scenarios/data_science/proposal/exp_gen/select/prompts.yaml
@@ -107,7 +107,10 @@ grade:
     Write a Python script named `grade.py` to evaluate `submission.csv` produced by a model.
     Input files (relative to current working directory):
     - `{{ input_folder }}/label.csv` and `submission.csv`
-    Output format: `{'score': float, 'metric': str}`
+    Output exactly one valid JSON object on one line, for example:
+    `{"score": 0.75, "metric": "auc"}`
+    Use `json.dumps(...)` to produce the output. Do not print a Python dictionary representation.
+    `score` must be a finite JSON number, not a string, boolean, NaN, or Infinity.
     {% if error %} 
     {{ error }}
     {% endif %}

--- a/rdagent/scenarios/data_science/proposal/exp_gen/select/submit.py
+++ b/rdagent/scenarios/data_science/proposal/exp_gen/select/submit.py
@@ -13,6 +13,7 @@ import numpy as np
 import pandas as pd
 import yaml
 from loguru import logger
+
 from rdagent.app.data_science.conf import DS_RD_SETTING
 from rdagent.components.coder.data_science.conf import get_ds_env
 from rdagent.core.experiment import FBWorkspace

--- a/rdagent/scenarios/data_science/proposal/exp_gen/select/submit.py
+++ b/rdagent/scenarios/data_science/proposal/exp_gen/select/submit.py
@@ -351,6 +351,38 @@ class ValidationSelector(SOTAexpSelector):
         print(grade_py_code)
         print("======== code end ========")
 
+    def _validate_grade_script(
+        self, grade_py_code: str, reference_exp: DSExperiment, mock_folder: str
+    ) -> None:
+        """Run a reusable grade script and verify its output contract."""
+        input_folder = T("scenarios.data_science.share:scen.input_path").r()
+        submission_path = Path(mock_folder) / "submission.csv"
+        if not submission_path.exists():
+            message = f"Cannot validate grade.py because {submission_path} does not exist."
+            raise RuntimeError(message)
+
+        ws = FBWorkspace()
+        ws.inject_code_from_file_dict(reference_exp.experiment_workspace)
+        ws.inject_files(**{"grade.py": grade_py_code})
+        shutil.copy(str(submission_path), str(ws.workspace_path / "submission.csv"))
+        env = get_ds_env(
+            extra_volumes={str(Path(mock_folder) / input_folder): {"bind": input_folder, "mode": "rw"}}
+        )
+        result = ws.run(env=env, entry=f"python grade.py --cache-buster={time.time()}")
+        stdout = re.sub(r"^chmod:.*\n?", "", result.stdout, flags=re.MULTILINE)
+
+        if result.exit_code != 0:
+            output = shrink_text(stdout, context_lines=20, line_len=500)
+            message = f"grade.py validation failed with exit code {result.exit_code}: {output}"
+            raise RuntimeError(message)
+        if _parsing_score(stdout) is None:
+            output = shrink_text(stdout, context_lines=20, line_len=500)
+            message = (
+                "grade.py must print a valid JSON object whose 'score' is a finite numeric value; "
+                f"received stdout: {output}"
+            )
+            raise RuntimeError(message)
+
     def _prepare_validation_scripts(
         self, reference_exp: DSExperiment, competition: str, mock_folder: str
     ) -> Tuple[str, str]:
@@ -391,6 +423,7 @@ class ValidationSelector(SOTAexpSelector):
                 )  # Do not cache the result
                 if result.exit_code == 0:
                     self.print_code(data_py_code, grade_py_code)
+            self._validate_grade_script(grade_py_code, reference_exp, mock_folder)
             return data_py_code, grade_py_code
 
         # --- Generate data.py if needed ---
@@ -409,23 +442,31 @@ class ValidationSelector(SOTAexpSelector):
         data_py_code = data_py_path.read_text()
 
         # --- Generate grade.py if needed ---
-        if not grade_py_path.exists():
-            logger.info(f"Generating grading script: {grade_py_path}")
-            grade_py_code = self._generate_and_run_script(
-                script_type="grade",
-                prompt_template_key="grade",
-                reference_exp=reference_exp,
-                competition=competition,
-                mock_folder=mock_folder,
-                prompt_kwargs={
-                    "reference_code": reference_code,
-                    "sample_code": data_py_code,
-                    "input_folder": input_folder,
-                },
-            )
-            grade_py_path.write_text(grade_py_code)
-            self.print_code(data_py_code, grade_py_code)
-        return data_py_code, grade_py_path.read_text()
+        if grade_py_path.exists():
+            grade_py_code = grade_py_path.read_text()
+            try:
+                self._validate_grade_script(grade_py_code, reference_exp, mock_folder)
+            except RuntimeError as exc:
+                logger.warning(f"Cached grade.py is incompatible and will be regenerated: {exc}")
+            else:
+                return data_py_code, grade_py_code
+
+        logger.info(f"Generating grading script: {grade_py_path}")
+        grade_py_code = self._generate_and_run_script(
+            script_type="grade",
+            prompt_template_key="grade",
+            reference_exp=reference_exp,
+            competition=competition,
+            mock_folder=mock_folder,
+            prompt_kwargs={
+                "reference_code": reference_code,
+                "sample_code": data_py_code,
+                "input_folder": input_folder,
+            },
+        )
+        grade_py_path.write_text(grade_py_code)
+        self.print_code(data_py_code, grade_py_code)
+        return data_py_code, grade_py_code
 
     def _generate_and_run_script(
         self,

--- a/rdagent/scenarios/data_science/proposal/exp_gen/select/submit.py
+++ b/rdagent/scenarios/data_science/proposal/exp_gen/select/submit.py
@@ -1,9 +1,9 @@
 import json
+import math
 import os
 import pickle
 import re
 import shutil
-import tarfile
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -13,7 +13,6 @@ import numpy as np
 import pandas as pd
 import yaml
 from loguru import logger
-
 from rdagent.app.data_science.conf import DS_RD_SETTING
 from rdagent.components.coder.data_science.conf import get_ds_env
 from rdagent.core.experiment import FBWorkspace
@@ -26,6 +25,7 @@ from rdagent.oai.llm_utils import APIBackend
 from rdagent.scenarios.data_science.experiment.experiment import DSExperiment
 from rdagent.utils.agent.ret import PythonAgentOut
 from rdagent.utils.agent.tpl import T
+from rdagent.utils.archive import safe_extract_tar
 from rdagent.utils.fmt import shrink_text
 from rdagent.utils.workflow import wait_retry
 
@@ -582,19 +582,14 @@ def _parsing_score(grade_stdout: str) -> Optional[float]:
             continue
         json_str = m.group(0)
         try:
-            # Priority 1: JSON parsing
-            return float(json.loads(json_str)["score"])
-        except:
-            pass
-        try:
-            # Priority 2: Eval dict
-            return float(eval(json_str)["score"])
-        except:
-            pass
-        try:
-            # Priority 3: Regex for the last number in the string
-            return float(re.findall(r"[-+]?\d*\.\d+|\d+", json_str)[-1])
-        except:
+            score = json.loads(json_str)["score"]
+            if isinstance(score, bool) or not isinstance(score, (int, float)):
+                continue
+            score = float(score)
+            if not math.isfinite(score):
+                continue
+            return score
+        except (KeyError, TypeError, ValueError):
             pass
     return None
 
@@ -626,9 +621,8 @@ def try_get_loop_id(trace: Trace, exp: DSExperiment):
     return index
 
 
-def extract_tar(tar_path: str, to_dir: str = "log") -> str:
-    with tarfile.open(tar_path, mode="r:*") as tar:
-        tar.extractall(path=to_dir)
+def extract_tar(tar_path: str, to_dir: str = "log") -> None:
+    safe_extract_tar(tar_path, to_dir)
 
 
 # ==============================================================================

--- a/rdagent/scenarios/data_science/proposal/exp_gen/select/submit.py
+++ b/rdagent/scenarios/data_science/proposal/exp_gen/select/submit.py
@@ -351,9 +351,7 @@ class ValidationSelector(SOTAexpSelector):
         print(grade_py_code)
         print("======== code end ========")
 
-    def _validate_grade_script(
-        self, grade_py_code: str, reference_exp: DSExperiment, mock_folder: str
-    ) -> None:
+    def _validate_grade_script(self, grade_py_code: str, reference_exp: DSExperiment, mock_folder: str) -> None:
         """Run a reusable grade script and verify its output contract."""
         input_folder = T("scenarios.data_science.share:scen.input_path").r()
         submission_path = Path(mock_folder) / "submission.csv"
@@ -365,9 +363,7 @@ class ValidationSelector(SOTAexpSelector):
         ws.inject_code_from_file_dict(reference_exp.experiment_workspace)
         ws.inject_files(**{"grade.py": grade_py_code})
         shutil.copy(str(submission_path), str(ws.workspace_path / "submission.csv"))
-        env = get_ds_env(
-            extra_volumes={str(Path(mock_folder) / input_folder): {"bind": input_folder, "mode": "rw"}}
-        )
+        env = get_ds_env(extra_volumes={str(Path(mock_folder) / input_folder): {"bind": input_folder, "mode": "rw"}})
         result = ws.run(env=env, entry=f"python grade.py --cache-buster={time.time()}")
         stdout = re.sub(r"^chmod:.*\n?", "", result.stdout, flags=re.MULTILINE)
 
@@ -394,6 +390,7 @@ class ValidationSelector(SOTAexpSelector):
         data_py_path = Path(mock_folder) / "data.py"
         grade_py_path = Path(mock_folder) / "grade.py"
         label_path = Path(mock_folder) / "workspace_input/label.csv"
+        submission_path = Path(mock_folder) / "submission.csv"
         reference_code = reference_exp.experiment_workspace.file_dict.get("main.py", "")
         if not reference_code:
             raise RuntimeError("ValidationSelector: No code found in the reference experiment.")
@@ -403,7 +400,7 @@ class ValidationSelector(SOTAexpSelector):
             shutil.copy(self.sample_code_path / competition / "grade.py", grade_py_path)
             data_py_code = data_py_path.read_text()
             grade_py_code = grade_py_path.read_text()
-            if not label_path.exists():
+            if not label_path.exists() or not submission_path.exists():
                 ws = FBWorkspace()
                 if self.sample_rate != 0.8:
                     data_py_code = data_py_code.replace("0.8", str(self.sample_rate)).replace(
@@ -427,7 +424,7 @@ class ValidationSelector(SOTAexpSelector):
             return data_py_code, grade_py_code
 
         # --- Generate data.py if needed ---
-        if not data_py_path.exists() or not label_path.exists():
+        if not data_py_path.exists() or not label_path.exists() or not submission_path.exists():
             logger.info(f"Generating synthetic data script: {data_py_path}")
             data_py_code = self._generate_and_run_script(
                 script_type="data",

--- a/rdagent/scenarios/kaggle/kaggle_crawler.py
+++ b/rdagent/scenarios/kaggle/kaggle_crawler.py
@@ -10,20 +10,21 @@ from itertools import chain
 from pathlib import Path
 
 import nbformat
-from rich import print
-from selenium import webdriver
-from selenium.webdriver.chrome.service import Service
-from selenium.webdriver.common.by import By
-from webdriver_manager.chrome import ChromeDriverManager
-
 from rdagent.core.conf import ExtendedBaseSettings
 from rdagent.core.exception import KaggleError
 from rdagent.core.utils import cache_with_pickle
 from rdagent.log import rdagent_logger as logger
 from rdagent.oai.llm_utils import APIBackend
 from rdagent.scenarios.data_science.debug.data import create_debug_data
+from rdagent.scenarios.kaggle.security import validate_competition_slug
 from rdagent.utils.agent.tpl import T
+from rdagent.utils.archive import safe_extract_tar, safe_extract_zip
 from rdagent.utils.env import MLEBDockerEnv
+from rich import print
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.common.by import By
+from webdriver_manager.chrome import ChromeDriverManager
 
 # %%
 options = webdriver.ChromeOptions()
@@ -35,6 +36,7 @@ options.add_argument("--headless")
 def crawl_descriptions(
     competition: str, local_data_path: str, wait: float = 3.0, force: bool = False
 ) -> dict[str, str] | str:
+    competition = validate_competition_slug(competition)
     if (fp := Path(f"{local_data_path}/{competition}/description.md")).exists() and not force:
         logger.info(f"Found {competition}/description.md, loading from it.")
         return fp.read_text()
@@ -108,6 +110,7 @@ def crawl_descriptions(
 
 
 def download_data(competition: str, settings: ExtendedBaseSettings, enable_create_debug_data: bool = True) -> None:
+    competition = validate_competition_slug(competition)
     local_path = settings.local_data_path
     if settings.if_using_mle_data:
         zipfile_path = f"{local_path}/zip_files"
@@ -135,33 +138,17 @@ def download_data(competition: str, settings: ExtendedBaseSettings, enable_creat
 
             for zip_path in competition_local_path.rglob("*.zip"):
                 with zipfile.ZipFile(zip_path, "r") as zip_ref:
-                    if len(zip_ref.namelist()) == 1:
-                        mleb_env.check_output(
-                            f"unzip -o ./{zip_path.relative_to(competition_local_path)} -d {zip_path.parent.relative_to(competition_local_path)}",
-                            local_path=competition_local_path,
-                        )
-                    else:
-                        mleb_env.check_output(
-                            f"mkdir -p ./{zip_path.parent.relative_to(competition_local_path)}/{zip_path.stem}; unzip -o ./{zip_path.relative_to(competition_local_path)} -d ./{zip_path.parent.relative_to(competition_local_path)}/{zip_path.stem}",
-                            local_path=competition_local_path,
-                        )
+                    extract_dir = zip_path.parent if len(zip_ref.namelist()) == 1 else zip_path.parent / zip_path.stem
+                safe_extract_zip(zip_path, extract_dir)
             for tar_path in competition_local_path.rglob("*.tar*"):
                 if not tarfile.is_tarfile(tar_path):
                     logger.error(f"{tar_path} is not a valid tar file.")
                     continue
-                is_gzip_file = open(tar_path, "rb").read(2) == b"\x1f\x8b"
-                with tarfile.open(tar_path, "r:gz") if is_gzip_file else tarfile.open(tar_path, "r") as tar_ref:
-                    if len(tar_ref.getmembers()) == 1:
-                        mleb_env.check_output(
-                            f"tar -{'xzf' if is_gzip_file else 'xf'} ./{tar_path.relative_to(competition_local_path)} -C {tar_path.parent.relative_to(competition_local_path)}",
-                            local_path=competition_local_path,
-                        )
-                    else:
-                        folder_name = tar_path.name.replace(".tar", "").replace(".gz", "")
-                        mleb_env.check_output(
-                            f"mkdir -p ./{tar_path.parent.relative_to(competition_local_path)}/{folder_name}; tar -{'xzf' if is_gzip_file else 'xf'} ./{tar_path.relative_to(competition_local_path)} -C ./{tar_path.parent.relative_to(competition_local_path)}/{folder_name}",
-                            local_path=competition_local_path,
-                        )
+                with tarfile.open(tar_path, "r:*") as tar_ref:
+                    member_count = len(tar_ref.getmembers())
+                folder_name = tar_path.name.replace(".tar", "").replace(".gz", "")
+                extract_dir = tar_path.parent if member_count == 1 else tar_path.parent / folder_name
+                safe_extract_tar(tar_path, extract_dir)
             # NOTE:
             # Patching:  due to mle has special renaming mechanism for different competition;
             # We have to switch the schema back to a uniform one;
@@ -201,12 +188,12 @@ def download_data(competition: str, settings: ExtendedBaseSettings, enable_creat
 
 
 def unzip_data(unzip_file_path: str, unzip_target_path: str) -> None:
-    with zipfile.ZipFile(unzip_file_path, "r") as zip_ref:
-        zip_ref.extractall(unzip_target_path)
+    safe_extract_zip(unzip_file_path, unzip_target_path)
 
 
 @cache_with_pickle(hash_func=lambda x: x, force=True)
 def leaderboard_scores(competition: str) -> list[float]:
+    competition = validate_competition_slug(competition)
     from kaggle.api.kaggle_api_extended import KaggleApi
 
     api = KaggleApi()
@@ -250,6 +237,7 @@ def score_rank(competition: str, score: float) -> tuple[int, float]:
 
 
 def download_notebooks(competition: str, local_path: str, num: int = 15) -> None:
+    competition = validate_competition_slug(competition)
     data_path = Path(f"{local_path}/{competition}")
     from kaggle.api.kaggle_api_extended import KaggleApi
 
@@ -285,6 +273,7 @@ def notebook_to_knowledge(notebook_text: str) -> str:
 
 
 def convert_notebooks_to_text(competition: str, local_path: str) -> None:
+    competition = validate_competition_slug(competition)
     data_path = Path(f"{local_path}/{competition}")
     converted_num = 0
 

--- a/rdagent/scenarios/kaggle/kaggle_crawler.py
+++ b/rdagent/scenarios/kaggle/kaggle_crawler.py
@@ -10,6 +10,12 @@ from itertools import chain
 from pathlib import Path
 
 import nbformat
+from rich import print
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.common.by import By
+from webdriver_manager.chrome import ChromeDriverManager
+
 from rdagent.core.conf import ExtendedBaseSettings
 from rdagent.core.exception import KaggleError
 from rdagent.core.utils import cache_with_pickle
@@ -20,11 +26,6 @@ from rdagent.scenarios.kaggle.security import validate_competition_slug
 from rdagent.utils.agent.tpl import T
 from rdagent.utils.archive import safe_extract_tar, safe_extract_zip
 from rdagent.utils.env import MLEBDockerEnv
-from rich import print
-from selenium import webdriver
-from selenium.webdriver.chrome.service import Service
-from selenium.webdriver.common.by import By
-from webdriver_manager.chrome import ChromeDriverManager
 
 # %%
 options = webdriver.ChromeOptions()

--- a/rdagent/scenarios/kaggle/security.py
+++ b/rdagent/scenarios/kaggle/security.py
@@ -1,0 +1,10 @@
+import re
+
+_COMPETITION_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,99}$")
+
+
+def validate_competition_slug(competition: str) -> str:
+    if not _COMPETITION_RE.fullmatch(competition):
+        message = "Competition must be a lowercase Kaggle slug containing only letters, digits, and hyphens"
+        raise ValueError(message)
+    return competition

--- a/rdagent/utils/archive.py
+++ b/rdagent/utils/archive.py
@@ -1,0 +1,95 @@
+import shutil
+import stat
+import tarfile
+import zipfile
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+DEFAULT_MAX_ARCHIVE_MEMBERS = 10_000
+DEFAULT_MAX_UNCOMPRESSED_BYTES = 10 * 1024 * 1024 * 1024
+
+
+def _safe_destination(root: Path, member_name: str) -> Path:
+    member_path = PurePosixPath(member_name.replace("\\", "/"))
+    if member_path.is_absolute() or PureWindowsPath(member_name).drive or ".." in member_path.parts:
+        message = f"Unsafe archive member path: {member_name}"
+        raise ValueError(message)
+    destination = root.joinpath(*member_path.parts).resolve()
+    try:
+        destination.relative_to(root)
+    except ValueError as exc:
+        message = f"Archive member escapes destination: {member_name}"
+        raise ValueError(message) from exc
+    return destination
+
+
+def safe_extract_zip(
+    archive_path: str | Path,
+    destination: str | Path,
+    *,
+    max_members: int = DEFAULT_MAX_ARCHIVE_MEMBERS,
+    max_uncompressed_bytes: int = DEFAULT_MAX_UNCOMPRESSED_BYTES,
+) -> None:
+    root = Path(destination).resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(archive_path) as archive:
+        members = archive.infolist()
+        if len(members) > max_members or sum(member.file_size for member in members) > max_uncompressed_bytes:
+            message = "Archive exceeds configured extraction limits"
+            raise ValueError(message)
+
+        targets: list[tuple[zipfile.ZipInfo, Path]] = []
+        for member in members:
+            target = _safe_destination(root, member.filename)
+            mode = member.external_attr >> 16
+            if stat.S_ISLNK(mode):
+                message = f"Archive links are not allowed: {member.filename}"
+                raise ValueError(message)
+            file_type = stat.S_IFMT(mode)
+            if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
+                message = f"Unsupported archive member type: {member.filename}"
+                raise ValueError(message)
+            targets.append((member, target))
+
+        for member, target in targets:
+            if member.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with archive.open(member) as source, target.open("wb") as output:
+                shutil.copyfileobj(source, output)
+
+
+def safe_extract_tar(
+    archive_path: str | Path,
+    destination: str | Path,
+    *,
+    max_members: int = DEFAULT_MAX_ARCHIVE_MEMBERS,
+    max_uncompressed_bytes: int = DEFAULT_MAX_UNCOMPRESSED_BYTES,
+) -> None:
+    root = Path(destination).resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(archive_path, mode="r:*") as archive:
+        members = archive.getmembers()
+        if len(members) > max_members or sum(member.size for member in members) > max_uncompressed_bytes:
+            message = "Archive exceeds configured extraction limits"
+            raise ValueError(message)
+
+        targets: list[tuple[tarfile.TarInfo, Path]] = []
+        for member in members:
+            target = _safe_destination(root, member.name)
+            if not member.isdir() and not member.isfile():
+                message = f"Unsupported archive member type: {member.name}"
+                raise ValueError(message)
+            targets.append((member, target))
+
+        for member, target in targets:
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            source = archive.extractfile(member)
+            if source is None:
+                message = f"Unable to read archive member: {member.name}"
+                raise ValueError(message)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with source, target.open("wb") as output:
+                shutil.copyfileobj(source, output)

--- a/rdagent/utils/env.py
+++ b/rdagent/utils/env.py
@@ -44,6 +44,15 @@ import docker.models.containers  # type: ignore[import-untyped]
 import docker.types  # type: ignore[import-untyped]
 from pydantic import BaseModel, model_validator
 from pydantic_settings import SettingsConfigDict
+from rich import print
+from rich.console import Console
+from rich.live import Live
+from rich.progress import Progress, SpinnerColumn, TextColumn
+from rich.rule import Rule
+from rich.table import Table
+from rich.text import Text
+from tqdm import tqdm
+
 from rdagent.core.conf import ExtendedBaseSettings
 from rdagent.core.experiment import RD_AGENT_SETTINGS
 from rdagent.core.utils import cache_with_pickle
@@ -53,14 +62,6 @@ from rdagent.utils import filter_redundant_text
 from rdagent.utils.agent.tpl import T
 from rdagent.utils.fmt import shrink_text
 from rdagent.utils.workflow import wait_retry
-from rich import print
-from rich.console import Console
-from rich.live import Live
-from rich.progress import Progress, SpinnerColumn, TextColumn
-from rich.rule import Rule
-from rich.table import Table
-from rich.text import Text
-from tqdm import tqdm
 
 CacheKeyFunc = Callable[[str | Path], list[list[str]]]
 

--- a/rdagent/utils/env.py
+++ b/rdagent/utils/env.py
@@ -44,15 +44,6 @@ import docker.models.containers  # type: ignore[import-untyped]
 import docker.types  # type: ignore[import-untyped]
 from pydantic import BaseModel, model_validator
 from pydantic_settings import SettingsConfigDict
-from rich import print
-from rich.console import Console
-from rich.live import Live
-from rich.progress import Progress, SpinnerColumn, TextColumn
-from rich.rule import Rule
-from rich.table import Table
-from rich.text import Text
-from tqdm import tqdm
-
 from rdagent.core.conf import ExtendedBaseSettings
 from rdagent.core.experiment import RD_AGENT_SETTINGS
 from rdagent.core.utils import cache_with_pickle
@@ -62,6 +53,14 @@ from rdagent.utils import filter_redundant_text
 from rdagent.utils.agent.tpl import T
 from rdagent.utils.fmt import shrink_text
 from rdagent.utils.workflow import wait_retry
+from rich import print
+from rich.console import Console
+from rich.live import Live
+from rich.progress import Progress, SpinnerColumn, TextColumn
+from rich.rule import Rule
+from rich.table import Table
+from rich.text import Text
+from tqdm import tqdm
 
 CacheKeyFunc = Callable[[str | Path], list[list[str]]]
 
@@ -872,16 +871,17 @@ FT_CONDA_CONFIG_DIR = Path(__file__).parent.parent / "scenarios" / "finetune" / 
 # Track which conda environments have been prepared in this process
 # This avoids redundant pip install checks that produce verbose output
 _CONDA_ENV_PREPARED: set[str] = set()
+_CONDA_ENV_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
+_PYTHON_VERSION_RE = re.compile(r"^\d+\.\d+(?:\.\d+)?$")
 
 
 def _sync_conda_cache_with_real_envs() -> None:
     """Ensure the prepared cache includes environments that already exist on disk."""
     try:
         result = subprocess.run(
-            "conda env list",
+            ["conda", "env", "list"],
             capture_output=True,
             text=True,
-            shell=True,
             check=False,
         )
     except Exception as exc:  # pragma: no cover - best-effort helper
@@ -913,15 +913,22 @@ def _prepare_conda_env(env_name: str, requirements_file: Path, python_version: s
         requirements_file: Path to requirements.txt file
         python_version: Python version for the environment
     """
-    # 1. Create conda environment if not exists
-    result = subprocess.run(f"conda env list | grep -q '^{env_name} '", shell=True)
-    if result.returncode != 0:
+    if not _CONDA_ENV_NAME_RE.fullmatch(env_name):
+        message = f"Invalid conda environment name: {env_name}"
+        raise ValueError(message)
+    if not _PYTHON_VERSION_RE.fullmatch(python_version):
+        message = f"Invalid Python version: {python_version}"
+        raise ValueError(message)
+
+    requirements_file = requirements_file.resolve()
+    _sync_conda_cache_with_real_envs()
+    if env_name not in _CONDA_ENV_PREPARED:
         print(f"[yellow]Creating conda env '{env_name}' (Python {python_version})...[/yellow]")
-        subprocess.check_call(f"conda create -y -n {env_name} python={python_version}", shell=True)
-        subprocess.check_call(f"conda run -n {env_name} pip install --upgrade pip", shell=True)
+        subprocess.check_call(["conda", "create", "-y", "-n", env_name, f"python={python_version}"])
+        subprocess.check_call(["conda", "run", "-n", env_name, "pip", "install", "--upgrade", "pip"])
 
     print(f"[yellow]Installing dependencies from {requirements_file.name}...[/yellow]")
-    subprocess.check_call(f"conda run -n {env_name} pip install -r {requirements_file}", shell=True)
+    subprocess.check_call(["conda", "run", "-n", env_name, "pip", "install", "-r", str(requirements_file)])
     print(f"[green]Conda env '{env_name}' ready[/green]")
 
     _CONDA_ENV_PREPARED.add(env_name)
@@ -961,8 +968,17 @@ class FTCondaEnv(LocalEnv[FTCondaConf]):
             # Note: flash-attn>=2.8 is required for B200 (sm_100) support
             print("[yellow]Installing flash-attn (compiling, may take a few minutes)...[/yellow]")
             subprocess.check_call(
-                f"conda run -n {self.conf.conda_env_name} pip install 'flash-attn>=2.8' --no-build-isolation --no-cache-dir",
-                shell=True,
+                [
+                    "conda",
+                    "run",
+                    "-n",
+                    self.conf.conda_env_name,
+                    "pip",
+                    "install",
+                    "flash-attn>=2.8",
+                    "--no-build-isolation",
+                    "--no-cache-dir",
+                ],
             )
 
             # Re-update bin_path after prepare() in case the conda env was just created

--- a/test/scenarios/data_science/test_secure_parsing.py
+++ b/test/scenarios/data_science/test_secure_parsing.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
+
 from rdagent.components.coder.finetune.unified_validator import LLMConfigValidator
 from rdagent.scenarios.data_science.proposal.exp_gen.select.submit import (
     ValidationSelector,
@@ -41,7 +42,10 @@ def test_score_parser_rejects_non_finite_or_non_numeric_values(score: str) -> No
     ],
 )
 def test_reusable_grade_script_requires_strict_json(
-    stdout: str, is_valid: bool, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,  # noqa: FBT001
+    stdout: str,
+    is_valid: bool,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,  # noqa: FBT001
 ) -> None:
     workspace_path = tmp_path / "workspace"
     workspace_path.mkdir()
@@ -55,7 +59,8 @@ def test_reusable_grade_script_requires_strict_json(
     )
     monkeypatch.setattr("rdagent.scenarios.data_science.proposal.exp_gen.select.submit.FBWorkspace", lambda: workspace)
     monkeypatch.setattr(
-        "rdagent.scenarios.data_science.proposal.exp_gen.select.submit.get_ds_env", lambda **_: object(),
+        "rdagent.scenarios.data_science.proposal.exp_gen.select.submit.get_ds_env",
+        lambda **_: object(),
     )
 
     selector = object.__new__(ValidationSelector)
@@ -73,6 +78,7 @@ def test_incompatible_cached_grade_script_is_regenerated(monkeypatch: pytest.Mon
     mock_folder = tmp_path / "mock"
     (mock_folder / "workspace_input").mkdir(parents=True)
     (mock_folder / "workspace_input" / "label.csv").touch()
+    (mock_folder / "submission.csv").touch()
     (mock_folder / "data.py").write_text("pass")
     (mock_folder / "grade.py").write_text("print({'score': 0.75})")
 
@@ -88,12 +94,48 @@ def test_incompatible_cached_grade_script_is_regenerated(monkeypatch: pytest.Mon
     reference_exp = SimpleNamespace(experiment_workspace=SimpleNamespace(file_dict={"main.py": "pass"}))
 
     _, grade_code = selector._prepare_validation_scripts(  # noqa: SLF001
-        reference_exp, "example-competition", str(mock_folder),
+        reference_exp,
+        "example-competition",
+        str(mock_folder),
     )
 
     assert grade_code == strict_grade_code
     assert (mock_folder / "grade.py").read_text() == strict_grade_code
     generate_mock.assert_called_once()
+
+
+@pytest.mark.offline
+def test_missing_cached_submission_is_recreated(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    mock_folder = tmp_path / "mock"
+    (mock_folder / "workspace_input").mkdir(parents=True)
+    (mock_folder / "workspace_input" / "label.csv").touch()
+    (mock_folder / "data.py").write_text("cached data")
+    strict_grade_code = 'import json; print(json.dumps({"score": 0.75}))'
+    (mock_folder / "grade.py").write_text(strict_grade_code)
+
+    selector = object.__new__(ValidationSelector)
+    selector.sample_code_path = tmp_path / "samples"
+    selector.sample_rate = 0.8
+    validate_mock = Mock()
+    monkeypatch.setattr(selector, "_validate_grade_script", validate_mock)
+
+    def regenerate_data(*, script_type: str, **_: object) -> str:
+        assert script_type == "data"
+        (mock_folder / "submission.csv").touch()
+        return "regenerated data"
+
+    generate_mock = Mock(side_effect=regenerate_data)
+    monkeypatch.setattr(selector, "_generate_and_run_script", generate_mock)
+    reference_exp = SimpleNamespace(experiment_workspace=SimpleNamespace(file_dict={"main.py": "pass"}))
+
+    data_code, grade_code = selector._prepare_validation_scripts(  # noqa: SLF001
+        reference_exp, "example-competition", str(mock_folder)
+    )
+
+    assert data_code == "regenerated data"
+    assert grade_code == strict_grade_code
+    generate_mock.assert_called_once()
+    validate_mock.assert_called_once_with(strict_grade_code, reference_exp, str(mock_folder))
 
 
 @pytest.mark.offline

--- a/test/scenarios/data_science/test_secure_parsing.py
+++ b/test/scenarios/data_science/test_secure_parsing.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 from rdagent.components.coder.finetune.unified_validator import LLMConfigValidator
 from rdagent.scenarios.data_science.proposal.exp_gen.select.submit import _parsing_score
 

--- a/test/scenarios/data_science/test_secure_parsing.py
+++ b/test/scenarios/data_science/test_secure_parsing.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import pytest
+from rdagent.components.coder.finetune.unified_validator import LLMConfigValidator
+from rdagent.scenarios.data_science.proposal.exp_gen.select.submit import _parsing_score
+
+EXPECTED_SCORE = 0.75
+
+
+@pytest.mark.offline
+def test_score_parser_accepts_finite_json_number() -> None:
+    assert _parsing_score('result: {"score": 0.75}') == EXPECTED_SCORE
+
+
+@pytest.mark.offline
+def test_score_parser_does_not_execute_python(tmp_path: Path) -> None:
+    marker = tmp_path / "executed"
+    payload = f'{{"score": __import__("pathlib").Path("{marker}").touch()}}'
+
+    assert _parsing_score(payload) is None
+    assert not marker.exists()
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize("score", ["NaN", "Infinity", "true", '"1.0"'])
+def test_score_parser_rejects_non_finite_or_non_numeric_values(score: str) -> None:
+    assert _parsing_score(f'{{"score": {score}}}') is None
+
+
+@pytest.mark.offline
+def test_training_metrics_parser_does_not_execute_python(tmp_path: Path) -> None:
+    marker = tmp_path / "executed"
+    stdout = f"Running training\n{{'train_runtime': __import__('pathlib').Path('{marker}').touch()}}"
+    validator = object.__new__(LLMConfigValidator)
+
+    parsed = validator._parse_execution_log(stdout, 0)  # noqa: SLF001
+
+    assert str(marker) not in parsed
+    assert not marker.exists()

--- a/test/scenarios/data_science/test_secure_parsing.py
+++ b/test/scenarios/data_science/test_secure_parsing.py
@@ -1,9 +1,13 @@
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
-
 from rdagent.components.coder.finetune.unified_validator import LLMConfigValidator
-from rdagent.scenarios.data_science.proposal.exp_gen.select.submit import _parsing_score
+from rdagent.scenarios.data_science.proposal.exp_gen.select.submit import (
+    ValidationSelector,
+    _parsing_score,
+)
 
 EXPECTED_SCORE = 0.75
 
@@ -26,6 +30,70 @@ def test_score_parser_does_not_execute_python(tmp_path: Path) -> None:
 @pytest.mark.parametrize("score", ["NaN", "Infinity", "true", '"1.0"'])
 def test_score_parser_rejects_non_finite_or_non_numeric_values(score: str) -> None:
     assert _parsing_score(f'{{"score": {score}}}') is None
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize(
+    ("stdout", "is_valid"),
+    [
+        ('{"score": 0.75, "metric": "auc"}', True),
+        ("{'score': 0.75, 'metric': 'auc'}", False),
+    ],
+)
+def test_reusable_grade_script_requires_strict_json(
+    stdout: str, is_valid: bool, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,  # noqa: FBT001
+) -> None:
+    workspace_path = tmp_path / "workspace"
+    workspace_path.mkdir()
+    (tmp_path / "submission.csv").touch()
+
+    workspace = SimpleNamespace(
+        workspace_path=workspace_path,
+        inject_code_from_file_dict=Mock(),
+        inject_files=Mock(),
+        run=Mock(return_value=SimpleNamespace(exit_code=0, stdout=stdout)),
+    )
+    monkeypatch.setattr("rdagent.scenarios.data_science.proposal.exp_gen.select.submit.FBWorkspace", lambda: workspace)
+    monkeypatch.setattr(
+        "rdagent.scenarios.data_science.proposal.exp_gen.select.submit.get_ds_env", lambda **_: object(),
+    )
+
+    selector = object.__new__(ValidationSelector)
+    reference_exp = SimpleNamespace(experiment_workspace=SimpleNamespace(file_dict={"main.py": "pass"}))
+
+    if is_valid:
+        selector._validate_grade_script("print('result')", reference_exp, str(tmp_path))  # noqa: SLF001
+    else:
+        with pytest.raises(RuntimeError, match="valid JSON object"):
+            selector._validate_grade_script("print('result')", reference_exp, str(tmp_path))  # noqa: SLF001
+
+
+@pytest.mark.offline
+def test_incompatible_cached_grade_script_is_regenerated(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    mock_folder = tmp_path / "mock"
+    (mock_folder / "workspace_input").mkdir(parents=True)
+    (mock_folder / "workspace_input" / "label.csv").touch()
+    (mock_folder / "data.py").write_text("pass")
+    (mock_folder / "grade.py").write_text("print({'score': 0.75})")
+
+    selector = object.__new__(ValidationSelector)
+    selector.sample_code_path = tmp_path / "samples"
+    selector.sample_rate = 0.8
+    validate_mock = Mock(side_effect=RuntimeError("legacy output"))
+    monkeypatch.setattr(selector, "_validate_grade_script", validate_mock)
+    strict_grade_code = 'import json; print(json.dumps({"score": 0.75}))'
+    generate_mock = Mock(return_value=strict_grade_code)
+    monkeypatch.setattr(selector, "_generate_and_run_script", generate_mock)
+    monkeypatch.setattr(selector, "print_code", Mock())
+    reference_exp = SimpleNamespace(experiment_workspace=SimpleNamespace(file_dict={"main.py": "pass"}))
+
+    _, grade_code = selector._prepare_validation_scripts(  # noqa: SLF001
+        reference_exp, "example-competition", str(mock_folder),
+    )
+
+    assert grade_code == strict_grade_code
+    assert (mock_folder / "grade.py").read_text() == strict_grade_code
+    generate_mock.assert_called_once()
 
 
 @pytest.mark.offline

--- a/test/utils/test_archive_security.py
+++ b/test/utils/test_archive_security.py
@@ -4,6 +4,7 @@ import zipfile
 from pathlib import Path
 
 import pytest
+
 from rdagent.scenarios.kaggle.security import validate_competition_slug
 from rdagent.utils.archive import safe_extract_tar, safe_extract_zip
 

--- a/test/utils/test_archive_security.py
+++ b/test/utils/test_archive_security.py
@@ -1,0 +1,75 @@
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+from rdagent.scenarios.kaggle.security import validate_competition_slug
+from rdagent.utils.archive import safe_extract_tar, safe_extract_zip
+
+
+@pytest.mark.offline
+def test_competition_slug_rejects_command_and_path_syntax() -> None:
+    assert validate_competition_slug("aerial-cactus-identification") == "aerial-cactus-identification"
+    for competition in ("../../tmp", "safe;touch-pwned", "UPPERCASE", "with space"):
+        with pytest.raises(ValueError, match="Competition"):
+            validate_competition_slug(competition)
+
+
+@pytest.mark.offline
+def test_safe_extract_zip_rejects_path_traversal(tmp_path: Path) -> None:
+    archive_path = tmp_path / "payload.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("../escaped.txt", "payload")
+
+    with pytest.raises(ValueError, match="Unsafe archive member"):
+        safe_extract_zip(archive_path, tmp_path / "output")
+    assert not (tmp_path / "escaped.txt").exists()
+
+
+@pytest.mark.offline
+def test_safe_extract_zip_rejects_windows_absolute_path(tmp_path: Path) -> None:
+    archive_path = tmp_path / "payload.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("C:\\escaped.txt", "payload")
+
+    with pytest.raises(ValueError, match="Unsafe archive member"):
+        safe_extract_zip(archive_path, tmp_path / "output")
+
+
+@pytest.mark.offline
+def test_safe_extract_zip_extracts_regular_files(tmp_path: Path) -> None:
+    archive_path = tmp_path / "safe.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("nested/result.txt", "safe content")
+
+    output = tmp_path / "output"
+    safe_extract_zip(archive_path, output)
+    assert (output / "nested" / "result.txt").read_text() == "safe content"
+
+
+@pytest.mark.offline
+def test_safe_extract_tar_rejects_links(tmp_path: Path) -> None:
+    archive_path = tmp_path / "payload.tar"
+    with tarfile.open(archive_path, "w") as archive:
+        member = tarfile.TarInfo("link")
+        member.type = tarfile.SYMTYPE
+        member.linkname = "../escaped.txt"
+        archive.addfile(member)
+
+    with pytest.raises(ValueError, match="Unsupported archive member type"):
+        safe_extract_tar(archive_path, tmp_path / "output")
+
+
+@pytest.mark.offline
+def test_safe_extract_tar_extracts_regular_files(tmp_path: Path) -> None:
+    archive_path = tmp_path / "safe.tar"
+    content = b"safe content"
+    with tarfile.open(archive_path, "w") as archive:
+        member = tarfile.TarInfo("nested/result.txt")
+        member.size = len(content)
+        archive.addfile(member, io.BytesIO(content))
+
+    output = tmp_path / "output"
+    safe_extract_tar(archive_path, output)
+    assert (output / "nested" / "result.txt").read_bytes() == content

--- a/test/utils/test_archive_security.py
+++ b/test/utils/test_archive_security.py
@@ -50,6 +50,19 @@ def test_safe_extract_zip_extracts_regular_files(tmp_path: Path) -> None:
 
 
 @pytest.mark.offline
+def test_safe_extract_zip_enforces_member_and_size_limits(tmp_path: Path) -> None:
+    archive_path = tmp_path / "limited.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("first.txt", "12")
+        archive.writestr("second.txt", "34")
+
+    with pytest.raises(ValueError, match="exceeds configured extraction limits"):
+        safe_extract_zip(archive_path, tmp_path / "members", max_members=1)
+    with pytest.raises(ValueError, match="exceeds configured extraction limits"):
+        safe_extract_zip(archive_path, tmp_path / "size", max_uncompressed_bytes=3)
+
+
+@pytest.mark.offline
 def test_safe_extract_tar_rejects_links(tmp_path: Path) -> None:
     archive_path = tmp_path / "payload.tar"
     with tarfile.open(archive_path, "w") as archive:
@@ -74,3 +87,18 @@ def test_safe_extract_tar_extracts_regular_files(tmp_path: Path) -> None:
     output = tmp_path / "output"
     safe_extract_tar(archive_path, output)
     assert (output / "nested" / "result.txt").read_bytes() == content
+
+
+@pytest.mark.offline
+def test_safe_extract_tar_enforces_member_and_size_limits(tmp_path: Path) -> None:
+    archive_path = tmp_path / "limited.tar"
+    with tarfile.open(archive_path, "w") as archive:
+        for name in ("first.txt", "second.txt"):
+            member = tarfile.TarInfo(name)
+            member.size = 2
+            archive.addfile(member, io.BytesIO(b"12"))
+
+    with pytest.raises(ValueError, match="exceeds configured extraction limits"):
+        safe_extract_tar(archive_path, tmp_path / "members", max_members=1)
+    with pytest.raises(ValueError, match="exceeds configured extraction limits"):
+        safe_extract_tar(archive_path, tmp_path / "size", max_uncompressed_bytes=3)

--- a/test/utils/test_conda_security.py
+++ b/test/utils/test_conda_security.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from rdagent.utils.env import _prepare_conda_env
+
+
+@pytest.mark.offline
+def test_prepare_conda_env_rejects_shell_metacharacters(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    subprocess_run = Mock()
+    monkeypatch.setattr("rdagent.utils.env.subprocess.run", subprocess_run)
+    requirements = tmp_path / "requirements.txt"
+    requirements.touch()
+
+    with pytest.raises(ValueError, match="Invalid conda environment name"):
+        _prepare_conda_env("safe; touch /tmp/pwned", requirements)
+    subprocess_run.assert_not_called()
+
+
+@pytest.mark.offline
+def test_prepare_conda_env_uses_argument_lists(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    check_call = Mock()
+    monkeypatch.setattr("rdagent.utils.env._sync_conda_cache_with_real_envs", Mock())
+    monkeypatch.setattr("rdagent.utils.env.subprocess.check_call", check_call)
+    monkeypatch.setattr("rdagent.utils.env._CONDA_ENV_PREPARED", set())
+    requirements = tmp_path / "requirements.txt"
+    requirements.touch()
+
+    _prepare_conda_env("safe-env", requirements)
+
+    assert check_call.call_args_list[0].args[0] == ["conda", "create", "-y", "-n", "safe-env", "python=3.10"]
+    assert all(isinstance(call.args[0], list) for call in check_call.call_args_list)

--- a/test/utils/test_conda_security.py
+++ b/test/utils/test_conda_security.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+
 from rdagent.utils.env import _prepare_conda_env
 
 

--- a/test/utils/test_ws.py
+++ b/test/utils/test_ws.py
@@ -74,3 +74,47 @@ class TestFBWorkspace(unittest.TestCase):
         ws.create_ws_ckp()
         ws.recover_ws_ckp()
         self.assertFalse((ws.workspace_path / "large.bin").exists())
+
+    def test_workspace_file_operations_reject_path_escape(self) -> None:
+        ws = FBWorkspace()
+        ws.workspace_path = self.tmp_path / "ws"
+        ws.prepare()
+
+        ws.inject_files(**{"file.py": "a", "nested/file.py": "b"})
+        self.assertEqual((ws.workspace_path / "file.py").read_text(), "a")
+        self.assertEqual((ws.workspace_path / "nested/file.py").read_text(), "b")
+
+        outside = self.tmp_path / "outside.txt"
+        outside.write_text("keep")
+        absolute_outside = self.tmp_path / "absolute.txt"
+
+        for escaped_path in ("../outside.txt", str(absolute_outside)):
+            with self.subTest(operation="inject", path=escaped_path), self.assertRaises(ValueError):
+                ws.inject_files(**{escaped_path: "escaped"})
+            with self.subTest(operation="inject-delete", path=escaped_path), self.assertRaises(ValueError):
+                ws.inject_files(**{escaped_path: FBWorkspace.DEL_KEY})
+            with self.subTest(operation="remove", path=escaped_path), self.assertRaises(ValueError):
+                ws.remove_files(escaped_path)
+
+        self.assertEqual(outside.read_text(), "keep")
+        self.assertFalse(absolute_outside.exists())
+
+    def test_workspace_file_operations_reject_symlink_escape(self) -> None:
+        ws = FBWorkspace()
+        ws.workspace_path = self.tmp_path / "ws"
+        ws.prepare()
+
+        outside = self.tmp_path / "outside"
+        outside.mkdir()
+        (ws.workspace_path / "link").symlink_to(outside, target_is_directory=True)
+
+        with self.assertRaises(ValueError):
+            ws.inject_files(**{"link/escaped.txt": "escaped"})
+
+        outside_file = outside / "existing.txt"
+        outside_file.write_text("keep")
+        with self.assertRaises(ValueError):
+            ws.remove_files("link/existing.txt")
+
+        self.assertFalse((outside / "escaped.txt").exists())
+        self.assertEqual(outside_file.read_text(), "keep")

--- a/test/utils/test_ws.py
+++ b/test/utils/test_ws.py
@@ -87,8 +87,9 @@ class TestFBWorkspace(unittest.TestCase):
         outside = self.tmp_path / "outside.txt"
         outside.write_text("keep")
         absolute_outside = self.tmp_path / "absolute.txt"
+        absolute_inside = ws.workspace_path / "absolute.txt"
 
-        for escaped_path in ("../outside.txt", str(absolute_outside)):
+        for escaped_path in ("../outside.txt", "nested/../file.py", str(absolute_outside), str(absolute_inside)):
             with self.subTest(operation="inject", path=escaped_path), self.assertRaises(ValueError):
                 ws.inject_files(**{escaped_path: "escaped"})
             with self.subTest(operation="inject-delete", path=escaped_path), self.assertRaises(ValueError):
@@ -118,3 +119,29 @@ class TestFBWorkspace(unittest.TestCase):
 
         self.assertFalse((outside / "escaped.txt").exists())
         self.assertEqual(outside_file.read_text(), "keep")
+
+    def test_workspace_delete_unlinks_leaf_symlink_without_deleting_target(self) -> None:
+        ws = FBWorkspace()
+        ws.workspace_path = self.tmp_path / "ws"
+        ws.prepare()
+
+        target = ws.workspace_path / "target.txt"
+        target.write_text("keep")
+        link = ws.workspace_path / "link.txt"
+        link.symlink_to(target)
+
+        ws.remove_files("link.txt")
+
+        self.assertFalse(link.is_symlink())
+        self.assertEqual(target.read_text(), "keep")
+
+        outside_target = self.tmp_path / "outside-target.txt"
+        outside_target.write_text("keep")
+        outside_link = ws.workspace_path / "outside-link.txt"
+        outside_link.symlink_to(outside_target)
+        outside_target.unlink()
+
+        ws.inject_files(**{"outside-link.txt": FBWorkspace.DEL_KEY})
+
+        self.assertFalse(outside_link.is_symlink())
+        self.assertFalse(outside_target.exists())


### PR DESCRIPTION
## Summary

- replace `eval()` of grading stdout with strict finite numeric JSON parsing
- replace training-metric `eval()` with `ast.literal_eval()` for legacy Python-dict output
- require generated grading scripts to emit strict numeric JSON
- validate reusable grading scripts and rebuild incomplete mock data when `submission.csv` is missing
- validate Kaggle competition slugs before using them in paths, API calls, or container command strings
- remove attacker-influenced shell extraction commands and add shared safe tar/zip extractors
- reject archive traversal, absolute paths, links, special files, and oversized archives
- validate conda environment names and Python versions
- replace affected conda `shell=True` commands with argument-list subprocess calls
- contain `FBWorkspace.inject_files()` and `remove_files()` operations within the resolved workspace root
- reject absolute paths, parent traversal, and symlink-directory escapes for workspace writes and deletes
- unlink leaf symlinks without deleting their targets, including dangling links

## Security impact

This prevents subprocess/container output from executing Python in the host process, neutralizes command metacharacters in competition and conda environment names, prevents crafted archives from writing outside their extraction directories, and prevents generated file names from writing to or deleting files outside an experiment workspace.

## Test plan

- `.venv/bin/pytest test/utils/test_ws.py test/utils/test_archive_security.py test/scenarios/data_science/test_secure_parsing.py test/utils/test_conda_security.py -q`
  - 25 tests and 12 subtests pass
- `python -m mypy rdagent/core`
- `ruff check rdagent/core --ignore FBT001,FBT002,I001,E501`
- `python -m isort --check . -s git_ignore_folder -s test/scripts -s test/notebook/testfiles -s web`
- `python -m black --check --diff . --extend-exclude "(test/scripts|test/notebook/testfiles|git_ignore_folder|web)" -l 120`
- `git diff --check`
- End-to-end Quant validation completed with `gpt-5.4-mini`:
  - Factor: two successful loops with non-empty factor artifacts and Qlib metrics
  - Model: two successful loops with non-empty predictions and Qlib metrics
  - Quant: two successful loops with complete propose/coding/running/feedback/record sessions and non-empty backtest artifacts
