### PR TITLE
ci: pin Python 3.10 compatible LiteLLM

### DIFF
--- a/constraints/3.10.txt
+++ b/constraints/3.10.txt
@@ -1,5 +1,6 @@
 azure-identity==1.17.1
 dill==0.3.9
+litellm==1.97.0
 pillow==10.4.0
 psutil==6.1.0
 scipy==1.14.1


### PR DESCRIPTION
## Summary

Pin LiteLLM to `1.97.0` in the Python 3.10 constraints file.

LiteLLM 1.98.0 and 1.99.0 import `NotRequired` directly from the standard-library `typing` module in an Anthropic context-management module. `typing.NotRequired` is only available from Python 3.11, so importing RD-Agent modules during the Python 3.10 Sphinx build fails before offline tests run.

The Python 3.11 constraints remain unchanged.

## Validation

Reproduced in a clean Python 3.10.12 virtual environment:

- LiteLLM 1.99.0: import fails
- LiteLLM 1.98.0: import fails
- LiteLLM 1.97.0: imports successfully
- `python -m sphinx.cmd.build -W docs <output>`: succeeds with LiteLLM 1.97.0

This intentionally uses a minimal package pin instead of regenerating the full constraints file, avoiding unrelated dependency changes.


<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1470.org.readthedocs.build/en/1470/

<!-- readthedocs-preview RDAgent end -->