### PR TITLE
fix: verify persisted artifacts before deserialization

### DIFF
--- a/docs/installation_and_configuration.rst
+++ b/docs/installation_and_configuration.rst
@@ -201,6 +201,88 @@ The execution environment is determined by the ``DS_CODER_COSTEER_ENV_TYPE`` var
        DS_CODER_COSTEER_ENV_TYPE=conda
 
 
+Persisted Artifact Security
+===========================
+
+RD-Agent persists Python objects for sessions, logs, caches, summaries, and
+knowledge bases. These objects use a signed serialization envelope. RD-Agent
+verifies the signature before invoking Python pickle or dill deserialization,
+and rejects unsigned or modified artifacts by default.
+
+The signing key is created automatically on first use at
+``~/.rdagent/artifact_signing.key`` with owner-only permissions. Back up this
+file if existing sessions and knowledge bases must remain readable. Losing or
+rotating the key makes artifacts signed by the previous key unavailable.
+
+The following environment variables control artifact verification:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 32 28 70
+
+   * - Environment variable
+     - Default
+     - Description
+   * - ``ARTIFACT_SIGNING_KEY``
+     - empty
+     - Optional signing secret containing at least 32 bytes. Use the same value
+       on trusted RD-Agent processes that share persisted artifacts. Prefer a
+       secret manager instead of committing it to a repository or ``.env``
+       file.
+   * - ``ARTIFACT_SIGNING_KEY_PATH``
+     - ``~/.rdagent/artifact_signing.key``
+     - Path used for the automatically generated local signing key when
+       ``ARTIFACT_SIGNING_KEY`` is not configured.
+   * - ``ALLOW_UNSAFE_LEGACY_PICKLE``
+     - ``false``
+     - Allows unsigned legacy pickle and dill artifacts. Enable temporarily
+       only when importing artifacts whose complete provenance is trusted.
+
+Keep the signing key outside log, cache, upload, workspace, and other shared
+artifact directories. Do not mount it into containers that execute generated
+or otherwise untrusted code. File access to the signing key is equivalent to
+permission to create artifacts trusted by the host process.
+
+Shared filesystems and multiple hosts
+-------------------------------------
+
+The automatically generated key is installation-local. If several trusted
+hosts read and write the same sessions, logs, caches, or knowledge bases,
+configure the same ``ARTIFACT_SIGNING_KEY`` through the deployment secret
+manager on every host. Artifacts written with a different key fail signature
+verification instead of being deserialized.
+
+Legacy artifact migration
+-------------------------
+
+Unsigned artifacts created by an earlier RD-Agent version are rejected by
+default. Legacy cache entries are treated as cache misses and rebuilt without
+executing their contents. For sessions, logs, summaries, and knowledge bases:
+
+#. Verify the artifact source and restrict write access to its directory.
+#. Back up both the artifact and the new signing key.
+#. Temporarily set ``ALLOW_UNSAFE_LEGACY_PICKLE=true`` in an isolated trusted
+   environment.
+#. Load the artifact and let the corresponding workflow save a new snapshot,
+   or export the needed data to a non-executable format.
+#. Disable ``ALLOW_UNSAFE_LEGACY_PICKLE`` immediately after migration.
+
+Never enable legacy loading for downloaded archives, shared directories, or
+paths writable by another user or service. HMAC verification establishes that
+an artifact was written by a holder of the signing key; it does not make an
+arbitrary pickle intrinsically safe.
+
+Container result formats
+------------------------
+
+Results crossing from generated/container code into the host process no longer
+use pickle. Supported values are transported with JSON manifests and typed
+files: Parquet for pandas tables, NPY with ``allow_pickle=False`` for numeric
+arrays, and JSON or text for simple values. Unsupported Python object types are
+rejected rather than deserialized on the host. Qlib tabular results and Kaggle
+validation cache data are stored as Parquet.
+
+
 Custom Time Segment Configuration (Train / Valid / Test)
 =========================================================
 
@@ -443,4 +525,3 @@ However, this feature is not enabled by default for other scripts. We recommend 
           export $(grep -v '^#' .env | xargs)
     
     - If you want to change the default environment variables, you can refer to the above configuration and edith the `.env` file.
-

--- a/rdagent/app/benchmark/factor/analysis.py
+++ b/rdagent/app/benchmark/factor/analysis.py
@@ -1,5 +1,4 @@
 import json
-import pickle
 from pathlib import Path
 
 import fire
@@ -10,6 +9,7 @@ import seaborn as sns
 
 from rdagent.components.benchmark.conf import BenchmarkSettings
 from rdagent.components.benchmark.eval_method import FactorImplementEval
+from rdagent.core.serialization import load as secure_pickle_load
 
 
 class BenchmarkAnalyzer:
@@ -32,7 +32,7 @@ class BenchmarkAnalyzer:
             raise ValueError("Invalid file path")
 
         with file_path.open("rb") as f:
-            res = pickle.load(f)
+            res = secure_pickle_load(f)
 
         return res
 

--- a/rdagent/app/finetune/llm/ui/ft_summary.py
+++ b/rdagent/app/finetune/llm/ui/ft_summary.py
@@ -3,7 +3,6 @@ FT Job Summary View
 Display summary table for all tasks in a job directory
 """
 
-import pickle
 from pathlib import Path
 
 import pandas as pd
@@ -11,6 +10,7 @@ import streamlit as st
 from pandas.io.formats.style import Styler
 
 from rdagent.app.finetune.llm.ui.benchmarks import get_core_metric_score
+from rdagent.core.serialization import load as secure_pickle_load
 
 
 def is_valid_task(task_path: Path) -> bool:
@@ -39,7 +39,7 @@ def extract_benchmark_score(loop_path: Path, split: str = "") -> tuple[str, floa
     for pkl_file in loop_path.rglob("**/benchmark_result*/**/*.pkl"):
         try:
             with open(pkl_file, "rb") as f:
-                content = pickle.load(f)
+                content = secure_pickle_load(f)
             if isinstance(content, dict):
                 # Check split filter
                 content_split = content.get("split", "")
@@ -83,7 +83,7 @@ def extract_baseline_score(task_path: Path) -> tuple[str, float] | None:
     for pkl_file in scenario_dir.rglob("*.pkl"):
         try:
             with open(pkl_file, "rb") as f:
-                scenario = pickle.load(f)
+                scenario = secure_pickle_load(f)
             baseline_score = getattr(scenario, "baseline_benchmark_score", None)
             if baseline_score and isinstance(baseline_score, dict):
                 benchmark_name = getattr(scenario, "target_benchmark", "")
@@ -112,7 +112,7 @@ def extract_baseline_scores(task_path: Path) -> dict[str, tuple[str, float, bool
     for pkl_file in scenario_dir.rglob("*.pkl"):
         try:
             with open(pkl_file, "rb") as f:
-                scenario = pickle.load(f)
+                scenario = secure_pickle_load(f)
 
             benchmark_name = getattr(scenario, "target_benchmark", "")
             result = {"validation": None, "test": None}
@@ -173,7 +173,7 @@ def get_loop_status(
     for f in feedback_files:
         try:
             with open(f, "rb") as fp:
-                content = pickle.load(fp)
+                content = secure_pickle_load(fp)
             decision = getattr(content, "decision", None)
             if decision is not None:
                 feedback_decision = decision
@@ -439,7 +439,7 @@ def extract_full_benchmark(loop_path: Path, split: str = "") -> dict | None:
     for pkl_file in loop_path.rglob("**/benchmark_result*/**/*.pkl"):
         try:
             with open(pkl_file, "rb") as f:
-                content = pickle.load(f)
+                content = secure_pickle_load(f)
             if isinstance(content, dict):
                 # Check split filter
                 content_split = content.get("split", "")
@@ -471,7 +471,7 @@ def extract_baseline_full_benchmark(task_path: Path, split: str = "validation") 
     for pkl_file in scenario_dir.rglob("*.pkl"):
         try:
             with open(pkl_file, "rb") as f:
-                scenario = pickle.load(f)
+                scenario = secure_pickle_load(f)
 
             if split == "validation":
                 baseline = getattr(scenario, "baseline_benchmark_score", None)

--- a/rdagent/app/rl/ui/data_loader.py
+++ b/rdagent/app/rl/ui/data_loader.py
@@ -4,7 +4,6 @@ Load pkl logs and convert to hierarchical timeline structure
 Simplified version: no EvoLoop (RL doesn't have evolution loops)
 """
 
-import pickle
 import re
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -14,6 +13,7 @@ from typing import Any
 import streamlit as st
 
 from rdagent.app.rl.ui.config import EventType
+from rdagent.core.serialization import load as secure_pickle_load
 from rdagent.log.storage import FileStorage
 
 
@@ -246,7 +246,7 @@ def load_session(log_path: Path) -> Session:
             continue
         try:
             with open(pkl_file, "rb") as f:
-                content = pickle.load(f)
+                content = secure_pickle_load(f)
             timestamp = datetime.strptime(pkl_file.stem, "%Y-%m-%d_%H-%M-%S-%f")
             # 正确解析 tag：Loop_5/running/debug_tpl/2957404/xxx.pkl -> Loop_5.running.debug_tpl
             tag = ".".join(pkl_file.relative_to(log_path).as_posix().replace("/", ".").split(".")[:-3])

--- a/rdagent/app/rl/ui/rl_summary.py
+++ b/rdagent/app/rl/ui/rl_summary.py
@@ -3,11 +3,12 @@ RL Job Summary View
 Display summary table for all tasks in a job directory
 """
 
-import pickle
 from pathlib import Path
 
 import pandas as pd
 import streamlit as st
+
+from rdagent.core.serialization import load as secure_pickle_load
 
 
 def is_valid_task(task_path: Path) -> bool:
@@ -37,7 +38,7 @@ def get_loop_status(task_path: Path, loop_id: int) -> tuple[str, bool | None]:
     for f in feedback_files:
         try:
             with open(f, "rb") as fp:
-                content = pickle.load(fp)
+                content = secure_pickle_load(fp)
             decision = getattr(content, "decision", None)
             if decision is not None:
                 feedback_decision = decision

--- a/rdagent/app/utils/ape.py
+++ b/rdagent/app/utils/ape.py
@@ -2,16 +2,16 @@
 This is the preliminary version of the APE (Automated Prompt Engineering)
 """
 
-import pickle
 from pathlib import Path
 
+from rdagent.core.serialization import load as secure_pickle_load
 from rdagent.log.conf import LOG_SETTINGS
 
 
 def get_llm_qa(file_path):
     data_flt = []
     with open(file_path, "rb") as f:
-        data = pickle.load(f)
+        data = secure_pickle_load(f)
         print(len(data))
         for item in data:
             if "debug_llm" in item["tag"]:

--- a/rdagent/components/coder/CoSTEER/knowledge_management.py
+++ b/rdagent/components/coder/CoSTEER/knowledge_management.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import copy
 import json
-import pickle
 import random
 import re
 from itertools import combinations
@@ -25,6 +24,8 @@ from rdagent.core.evolving_framework import (
     RAGStrategy,
 )
 from rdagent.core.experiment import FBWorkspace, Task
+from rdagent.core.serialization import dump as secure_pickle_dump
+from rdagent.core.serialization import load as secure_pickle_load
 from rdagent.log import rdagent_logger as logger
 from rdagent.oai.llm_utils import (
     APIBackend,
@@ -61,7 +62,8 @@ class CoSTEERRAGStrategy(RAGStrategy):
         self, former_knowledge_base_path: Path = None, component_init_list: list = [], evolving_version: int = 2
     ) -> EvolvingKnowledgeBase:
         if former_knowledge_base_path is not None and former_knowledge_base_path.exists():
-            knowledge_base = pickle.load(open(former_knowledge_base_path, "rb"))
+            with former_knowledge_base_path.open("rb") as f:
+                knowledge_base = secure_pickle_load(f)
             if evolving_version == 1 and not isinstance(knowledge_base, CoSTEERKnowledgeBaseV1):
                 raise ValueError("The former knowledge base is not compatible with the current version")
             elif evolving_version == 2 and not isinstance(
@@ -86,7 +88,7 @@ class CoSTEERRAGStrategy(RAGStrategy):
             if not self.dump_knowledge_base_path.parent.exists():
                 self.dump_knowledge_base_path.parent.mkdir(parents=True, exist_ok=True)
             with open(self.dump_knowledge_base_path, "wb") as f:
-                pickle.dump(self.knowledgebase, f)
+                secure_pickle_dump(self.knowledgebase, f)
 
     def load_dumped_knowledge_base(self, *args, **kwargs):
         if self.dump_knowledge_base_path is None:
@@ -95,7 +97,7 @@ class CoSTEERRAGStrategy(RAGStrategy):
             logger.info(f"Dumped knowledge base {self.dump_knowledge_base_path} does not exist, skip loading.")
         else:
             with open(self.dump_knowledge_base_path, "rb") as f:
-                self.knowledgebase = pickle.load(f)
+                self.knowledgebase = secure_pickle_load(f)
             logger.info(f"Loaded dumped knowledge base from {self.dump_knowledge_base_path}")
 
 

--- a/rdagent/components/coder/data_science/ensemble/exp.py
+++ b/rdagent/components/coder/data_science/ensemble/exp.py
@@ -1,4 +1,3 @@
-import pickle
 import site
 import traceback
 from pathlib import Path

--- a/rdagent/components/coder/data_science/feature/exp.py
+++ b/rdagent/components/coder/data_science/feature/exp.py
@@ -1,4 +1,3 @@
-import pickle
 import site
 import traceback
 from pathlib import Path

--- a/rdagent/components/coder/data_science/workflow/exp.py
+++ b/rdagent/components/coder/data_science/workflow/exp.py
@@ -1,4 +1,3 @@
-import pickle
 import site
 import traceback
 from pathlib import Path

--- a/rdagent/components/coder/model_coder/model.py
+++ b/rdagent/components/coder/model_coder/model.py
@@ -1,4 +1,3 @@
-import pickle
 import site
 import traceback
 from pathlib import Path
@@ -140,7 +139,7 @@ PARAM_INIT_VALUE = {param_init_value}
 
             log, results = qtde.dump_python_code_run_and_get_results(
                 code=dump_code,
-                dump_file_names=["execution_feedback_str.pkl", "execution_model_output.pkl"],
+                dump_file_names=["execution_feedback_str.txt", "execution_model_output.npy"],
                 local_path=str(self.workspace_path),
                 env={},
                 code_dump_file_py_name="model_test",

--- a/rdagent/components/coder/model_coder/model_execute_template_v1.txt
+++ b/rdagent/components/coder/model_coder/model_execute_template_v1.txt
@@ -6,8 +6,7 @@
 # INPUT_VALUE = 1.0
 # PARAM_INIT_VALUE = 1.0
 
-import pickle
-
+import numpy as np
 import torch
 from model import model_cls
 
@@ -40,5 +39,6 @@ else:
 execution_model_output = out.cpu().detach().numpy()
 execution_feedback_str = f"Execution successful, output tensor shape: {execution_model_output.shape}"
 
-pickle.dump(execution_model_output, open("execution_model_output.pkl", "wb"))
-pickle.dump(execution_feedback_str, open("execution_feedback_str.pkl", "wb"))
+np.save("execution_model_output.npy", execution_model_output, allow_pickle=False)
+with open("execution_feedback_str.txt", "w") as f:
+    f.write(execution_feedback_str)

--- a/rdagent/components/coder/model_coder/model_execute_template_v2.txt
+++ b/rdagent/components/coder/model_coder/model_execute_template_v2.txt
@@ -1,5 +1,4 @@
 import os
-import pickle
 
 import numpy as np
 import pandas as pd
@@ -20,5 +19,6 @@ if isinstance(execution_model_output, torch.Tensor):
 
 execution_feedback_str = f"Execution successful, output numpy ndarray shape: {execution_model_output.shape}"
 
-pickle.dump(execution_model_output, open("execution_model_output.pkl", "wb"))
-pickle.dump(execution_feedback_str, open("execution_feedback_str.pkl", "wb"))
+np.save("execution_model_output.npy", execution_model_output, allow_pickle=False)
+with open("execution_feedback_str.txt", "w") as f:
+    f.write(execution_feedback_str)

--- a/rdagent/components/knowledge_management/graph.py
+++ b/rdagent/components/knowledge_management/graph.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pickle
 import random
 from collections import deque
 from pathlib import Path

--- a/rdagent/core/conf.py
+++ b/rdagent/core/conf.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import cast
 
+from pydantic import Field
 from pydantic_settings import (
     BaseSettings,
     EnvSettingsSource,
@@ -70,6 +71,9 @@ class RDAgentSettings(ExtendedBaseSettings):
     pickle_cache_folder_path_str: str = str(
         Path.cwd() / "pickle_cache/",
     )  # the path of the folder to store the pickle cache
+    artifact_signing_key: str = Field(default="", exclude=True, repr=False)
+    artifact_signing_key_path: Path = Path.home() / ".rdagent" / "artifact_signing.key"
+    allow_unsafe_legacy_pickle: bool = False
     use_file_lock: bool = (
         True  # when calling the function with same parameters, whether to use file lock to avoid
         # executing the function multiple times

--- a/rdagent/core/knowledge_base.py
+++ b/rdagent/core/knowledge_base.py
@@ -2,6 +2,8 @@ from pathlib import Path
 
 import dill as pickle  # type: ignore[import-untyped]
 
+from rdagent.core.serialization import dump as secure_pickle_dump
+from rdagent.core.serialization import load as secure_pickle_load
 from rdagent.log import rdagent_logger as logger
 
 
@@ -13,7 +15,7 @@ class KnowledgeBase:
     def load(self) -> None:
         if self.path is not None and self.path.exists():
             with self.path.open("rb") as f:
-                loaded = pickle.load(f)
+                loaded = secure_pickle_load(f, serializer=pickle)
                 if isinstance(loaded, dict):
                     self.__dict__.update({k: v for k, v in loaded.items() if k != "path"})
                 else:
@@ -22,6 +24,7 @@ class KnowledgeBase:
     def dump(self) -> None:
         if self.path is not None:
             self.path.parent.mkdir(parents=True, exist_ok=True)
-            pickle.dump(self.__dict__, self.path.open("wb"))
+            with self.path.open("wb") as f:
+                secure_pickle_dump(self.__dict__, f, serializer=pickle)
         else:
             logger.warning("KnowledgeBase path is not set, dump failed.")

--- a/rdagent/core/serialization.py
+++ b/rdagent/core/serialization.py
@@ -1,0 +1,104 @@
+import contextlib
+import hashlib
+import hmac
+import os
+import pickle
+import secrets
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, BinaryIO, Protocol
+
+from filelock import FileLock
+
+from rdagent.core.conf import RD_AGENT_SETTINGS
+
+_MAGIC = b"RDAGENT_SIGNED_PICKLE_V1\n"
+_DIGEST_SIZE = hashlib.sha256().digest_size
+_MIN_KEY_BYTES = 32
+
+
+class PickleSerializer(Protocol):
+    def dumps(self, obj: object, protocol: int | None = None) -> bytes: ...
+
+    def loads(self, data: bytes) -> Any: ...
+
+
+class UntrustedArtifactError(ValueError):
+    """Raised before deserialization when an artifact is unsigned or has been modified."""
+
+
+@lru_cache(maxsize=8)
+def _signing_key_from_config(configured_key: str, configured_path: str) -> bytes:
+    if configured_key:
+        if len(configured_key.encode()) < _MIN_KEY_BYTES:
+            message = "ARTIFACT_SIGNING_KEY must contain at least 32 bytes"
+            raise ValueError(message)
+        return hashlib.sha256(configured_key.encode()).digest()
+
+    key_path = Path(configured_path).expanduser().resolve()
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    with FileLock(f"{key_path}.lock"):
+        try:
+            descriptor = os.open(key_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileExistsError:
+            key = key_path.read_bytes()
+        else:
+            key = secrets.token_bytes(32)
+            with os.fdopen(descriptor, "wb") as key_file:
+                key_file.write(key)
+    if len(key) < _MIN_KEY_BYTES:
+        message = f"Artifact signing key at {key_path} must contain at least 32 bytes"
+        raise ValueError(message)
+    with contextlib.suppress(OSError):
+        key_path.chmod(0o600)
+    return key
+
+
+def _signing_key() -> bytes:
+    return _signing_key_from_config(
+        RD_AGENT_SETTINGS.artifact_signing_key,
+        str(RD_AGENT_SETTINGS.artifact_signing_key_path),
+    )
+
+
+def dumps(obj: object, *, serializer: PickleSerializer = pickle) -> bytes:
+    payload = serializer.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
+    digest = hmac.digest(_signing_key(), payload, "sha256")
+    return _MAGIC + digest + payload
+
+
+def loads(
+    data: bytes,
+    *,
+    serializer: PickleSerializer = pickle,
+    allow_unsafe_legacy: bool | None = None,
+) -> Any:
+    if data.startswith(_MAGIC):
+        digest_start = len(_MAGIC)
+        digest_end = digest_start + _DIGEST_SIZE
+        digest = data[digest_start:digest_end]
+        payload = data[digest_end:]
+        expected = hmac.digest(_signing_key(), payload, "sha256")
+        if len(digest) != _DIGEST_SIZE or not hmac.compare_digest(digest, expected):
+            message = "Artifact signature verification failed"
+            raise UntrustedArtifactError(message)
+        return serializer.loads(payload)
+
+    allow_legacy = RD_AGENT_SETTINGS.allow_unsafe_legacy_pickle if allow_unsafe_legacy is None else allow_unsafe_legacy
+    if not allow_legacy:
+        message = "Unsigned legacy pickle rejected; enable ALLOW_UNSAFE_LEGACY_PICKLE only for trusted artifacts"
+        raise UntrustedArtifactError(message)
+    return serializer.loads(data)
+
+
+def dump(obj: object, file: BinaryIO, *, serializer: PickleSerializer = pickle) -> None:
+    file.write(dumps(obj, serializer=serializer))
+
+
+def load(
+    file: BinaryIO,
+    *,
+    serializer: PickleSerializer = pickle,
+    allow_unsafe_legacy: bool | None = None,
+) -> Any:
+    return loads(file.read(), serializer=serializer, allow_unsafe_legacy=allow_unsafe_legacy)

--- a/rdagent/core/utils.py
+++ b/rdagent/core/utils.py
@@ -14,6 +14,9 @@ from filelock import FileLock
 from fuzzywuzzy import fuzz  # type: ignore[import-untyped]
 
 from rdagent.core.conf import RD_AGENT_SETTINGS
+from rdagent.core.serialization import UntrustedArtifactError
+from rdagent.core.serialization import dump as secure_pickle_dump
+from rdagent.core.serialization import load as secure_pickle_load
 from rdagent.oai.llm_conf import LLM_SETTINGS
 
 
@@ -190,9 +193,15 @@ def cache_with_pickle(hash_func: Callable, post_process_func: Callable | None = 
             lock_file = target_folder / f"{hash_key}.lock"
 
             if cache_file.exists():
-                with cache_file.open("rb") as f:
-                    cached_res = pickle.load(f)
-                return post_process_func(*args, cached_res=cached_res, **kwargs) if post_process_func else cached_res
+                try:
+                    with cache_file.open("rb") as f:
+                        cached_res = secure_pickle_load(f)
+                except UntrustedArtifactError:
+                    cache_file.unlink(missing_ok=True)
+                else:
+                    return (
+                        post_process_func(*args, cached_res=cached_res, **kwargs) if post_process_func else cached_res
+                    )
 
             if RD_AGENT_SETTINGS.use_file_lock:
                 with FileLock(lock_file):
@@ -201,7 +210,7 @@ def cache_with_pickle(hash_func: Callable, post_process_func: Callable | None = 
                 result = func(*args, **kwargs)
 
             with cache_file.open("wb") as f:
-                pickle.dump(result, f)
+                secure_pickle_dump(result, f)
 
             return result
 

--- a/rdagent/log/mle_summary.py
+++ b/rdagent/log/mle_summary.py
@@ -1,4 +1,3 @@
-import pickle
 import traceback
 from collections import defaultdict
 from pathlib import Path
@@ -8,6 +7,8 @@ import pandas as pd
 
 from rdagent.core.experiment import FBWorkspace
 from rdagent.core.proposal import ExperimentFeedback
+from rdagent.core.serialization import dump as secure_pickle_dump
+from rdagent.core.serialization import load as secure_pickle_load
 from rdagent.log.storage import FileStorage
 from rdagent.log.utils import extract_json, extract_loopid_func_name, is_valid_session
 from rdagent.log.utils.folder import get_first_session_file_after_duration
@@ -55,7 +56,7 @@ def _get_loop_and_fn_after_hours(log_folder: Path, hours: int):
     stop_session_fp = get_first_session_file_after_duration(log_folder, f"{hours}h")
 
     with stop_session_fp.open("rb") as f:
-        session_obj: LoopBase = pickle.load(f)
+        session_obj: LoopBase = secure_pickle_load(f)
 
     loop_trace = session_obj.loop_trace
     stop_li = max(loop_trace.keys())
@@ -218,7 +219,8 @@ def summarize_folder(log_folder: Path, hours: int | None = None) -> None:
     if save_p.exists():
         save_p.unlink()
         print(f"Old {save_name} removed.")
-    pd.to_pickle(stat, save_p)
+    with save_p.open("wb") as f:
+        secure_pickle_dump(stat, f)
 
 
 # {

--- a/rdagent/log/storage.py
+++ b/rdagent/log/storage.py
@@ -1,9 +1,11 @@
 import json
-import pickle
 import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Generator, Literal
+
+from rdagent.core.serialization import dump as secure_pickle_dump
+from rdagent.core.serialization import load as secure_pickle_load
 
 from .base import Message, Storage
 from .utils import gen_datetime
@@ -62,7 +64,7 @@ class FileStorage(Storage):
         elif save_type == "pkl":
             path = path.with_suffix(".pkl")
             with path.open("wb") as f:
-                pickle.dump(obj, f)
+                secure_pickle_dump(obj, f)
             return path
         elif save_type == "text":
             obj = str(obj)
@@ -92,7 +94,7 @@ class FileStorage(Storage):
             pid = file.parent.name
 
             with file.open("rb") as f:
-                content = pickle.load(f)
+                content = secure_pickle_load(f)
 
             timestamp = datetime.strptime(file.stem, "%Y-%m-%d_%H-%M-%S-%f").replace(tzinfo=timezone.utc)
 

--- a/rdagent/log/ui/ds_trace.py
+++ b/rdagent/log/ui/ds_trace.py
@@ -1,6 +1,5 @@
 import hashlib
 import json
-import pickle
 import random
 import re
 from collections import defaultdict
@@ -14,6 +13,7 @@ from litellm import get_valid_models
 from streamlit import session_state as state
 
 from rdagent.app.data_science.loop import DataScienceRDLoop
+from rdagent.core.serialization import loads as secure_pickle_loads
 from rdagent.log.storage import FileStorage
 from rdagent.log.ui.conf import UI_SETTING
 from rdagent.log.ui.utils import (
@@ -141,7 +141,7 @@ def load_data(log_path: Path):
     llm_log_p = log_path / "debug_llm.pkl"
     if llm_log_p.exists():
         try:
-            rd = pickle.loads(llm_log_p.read_bytes())
+            rd = secure_pickle_loads(llm_log_p.read_bytes())
         except:
             rd = []
         for d in rd:

--- a/rdagent/log/ui/ds_user_interact.py
+++ b/rdagent/log/ui/ds_user_interact.py
@@ -1,5 +1,4 @@
 import json
-import pickle
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -8,6 +7,8 @@ import streamlit as st
 from streamlit import session_state as state
 
 from rdagent.app.data_science.conf import DS_RD_SETTING
+from rdagent.core.serialization import dump as secure_pickle_dump
+from rdagent.core.serialization import load as secure_pickle_load
 
 st.set_page_config(layout="wide", page_title="RD-Agent_user_interact", page_icon="🎓", initial_sidebar_state="expanded")
 
@@ -116,14 +117,12 @@ def render_main_content():
                     state.selected_session_name = None
 
             if st.button("Extend expiration by 60s"):
-                session_data = pickle.load(
-                    open(DS_RD_SETTING.user_interaction_mid_folder / f"{state.selected_session_name}.pkl", "rb")
-                )
+                session_path = DS_RD_SETTING.user_interaction_mid_folder / f"{state.selected_session_name}.pkl"
+                with session_path.open("rb") as f:
+                    session_data = secure_pickle_load(f)
                 session_data["expired_datetime"] = session_data["expired_datetime"] + timedelta(seconds=60)
-                pickle.dump(
-                    session_data,
-                    open(DS_RD_SETTING.user_interaction_mid_folder / f"{state.selected_session_name}.pkl", "wb"),
-                )
+                with session_path.open("wb") as f:
+                    secure_pickle_dump(session_data, f)
     else:
         st.warning("Please select a session from the sidebar.")
 
@@ -135,7 +134,8 @@ def update_sessions():
     state.sessions = {}
     for session_file in log_folder.glob("*.pkl"):
         try:
-            session_data = pickle.load(open(session_file, "rb"))
+            with session_file.open("rb") as f:
+                session_data = secure_pickle_load(f)
             if session_data["expired_datetime"] > datetime.now():
                 state.sessions[session_file.stem] = session_data
             else:

--- a/rdagent/log/ui/llm_st.py
+++ b/rdagent/log/ui/llm_st.py
@@ -1,6 +1,5 @@
 import argparse
 import json
-import pickle
 import re
 import time
 from pathlib import Path
@@ -8,6 +7,7 @@ from pathlib import Path
 import streamlit as st
 from streamlit import session_state
 
+from rdagent.core.serialization import load as secure_pickle_load
 from rdagent.log.ui.conf import UI_SETTING
 from rdagent.log.utils import extract_evoid, extract_loopid_func_name
 
@@ -56,7 +56,7 @@ def load_data():
         with st.spinner(f"正在加载数据文件 {log_file}..."):
             start_time = time.time()
             with open(log_file, "rb") as f:
-                session_state.data = pickle.load(f)
+                session_state.data = secure_pickle_load(f)
             st.success(f"数据加载完成！耗时 {time.time() - start_time:.2f} 秒")
             st.session_state["current_loop"] = 1
     except Exception as e:

--- a/rdagent/log/ui/utils.py
+++ b/rdagent/log/ui/utils.py
@@ -1,5 +1,4 @@
 import math
-import pickle
 import re
 from collections import defaultdict, deque
 from datetime import datetime, timedelta
@@ -16,6 +15,7 @@ from matplotlib import pyplot as plt
 
 from rdagent.app.data_science.loop import DataScienceRDLoop
 from rdagent.core.proposal import Trace
+from rdagent.core.serialization import load as secure_pickle_load
 from rdagent.core.utils import cache_with_pickle
 from rdagent.log.storage import FileStorage
 from rdagent.log.ui.conf import UI_SETTING
@@ -452,7 +452,8 @@ def get_summary_df(log_folder: str | Path, hours: int | None = None) -> tuple[di
     log_folder = Path(log_folder)
     sn = "summary.pkl" if hours is None else f"summary_{hours}h.pkl"
     if (log_folder / sn).exists():
-        summary: dict = pd.read_pickle(log_folder / sn)
+        with (log_folder / sn).open("rb") as f:
+            summary: dict = secure_pickle_load(f)
     else:
         return {}, pd.DataFrame()
 

--- a/rdagent/log/utils/folder.py
+++ b/rdagent/log/utils/folder.py
@@ -2,12 +2,12 @@
 This module provides some useful functions for working with logger folders.
 """
 
-import pickle
 from datetime import timedelta
 from pathlib import Path
 
 import pandas as pd
 
+from rdagent.core.serialization import load as secure_pickle_load
 from rdagent.utils.workflow import LoopBase
 
 
@@ -21,7 +21,7 @@ def get_first_session_file_after_duration(log_folder: str | Path, duration: str 
     fp = None
     for fp in files:
         with fp.open("rb") as f:
-            session_obj: LoopBase = pickle.load(f)
+            session_obj: LoopBase = secure_pickle_load(f)
         timer = session_obj.timer
         all_duration = timer.all_duration
         remain_time_duration = timer.remain_time()
@@ -70,7 +70,7 @@ if __name__ == "__main__":
     f = get_first_session_file_after_duration("<path to log aptos2019-blindness-detection>", pd.Timedelta("12h"))
 
     with f.open("rb") as f:
-        session_obj: LoopBase = pickle.load(f)
+        session_obj: LoopBase = secure_pickle_load(f)
     loop_trace = session_obj.loop_trace
     last_loop = loop_trace[max(loop_trace.keys())]
     last_step = last_loop[-1]

--- a/rdagent/scenarios/data_science/interactor/__init__.py
+++ b/rdagent/scenarios/data_science/interactor/__init__.py
@@ -1,5 +1,4 @@
 import json
-import pickle
 import time
 import uuid
 from abc import abstractmethod
@@ -9,6 +8,8 @@ from pathlib import Path
 from rdagent.app.data_science.conf import DS_RD_SETTING
 from rdagent.core.experiment import Task
 from rdagent.core.interactor import Interactor
+from rdagent.core.serialization import dump as secure_pickle_dump
+from rdagent.core.serialization import load as secure_pickle_load
 from rdagent.scenarios.data_science.experiment.experiment import DSExperiment
 from rdagent.scenarios.data_science.proposal.exp_gen.base import DSHypothesis, DSTrace
 from rdagent.utils.agent.tpl import T
@@ -95,17 +96,21 @@ class FBDSInteractor(DSInteractor):
         }
         session_id = uuid.uuid4().hex
         DS_RD_SETTING.user_interaction_mid_folder.mkdir(parents=True, exist_ok=True)
-        pickle.dump(information_to_user, open(DS_RD_SETTING.user_interaction_mid_folder / f"{session_id}.pkl", "wb"))
+        session_path = DS_RD_SETTING.user_interaction_mid_folder / f"{session_id}.pkl"
+        with session_path.open("wb") as f:
+            secure_pickle_dump(information_to_user, f)
+
+        def load_session_data() -> dict:
+            with session_path.open("rb") as f:
+                return secure_pickle_load(f)
+
         while (
-            Path(DS_RD_SETTING.user_interaction_mid_folder / f"{session_id}.pkl").exists()
-            and pickle.load(open(DS_RD_SETTING.user_interaction_mid_folder / f"{session_id}.pkl", "rb"))[
-                "expired_datetime"
-            ]
-            > datetime.now()
+            session_path.exists()
+            and load_session_data()["expired_datetime"] > datetime.now()
             and not (DS_RD_SETTING.user_interaction_mid_folder / f"{session_id}_RET.json").exists()
         ):
             time.sleep(5)
-        Path(DS_RD_SETTING.user_interaction_mid_folder / f"{session_id}.pkl").unlink(missing_ok=True)
+        session_path.unlink(missing_ok=True)
         if not (DS_RD_SETTING.user_interaction_mid_folder / f"{session_id}_RET.json").exists():
             return exp
         else:

--- a/rdagent/scenarios/data_science/proposal/exp_gen/select/submit.py
+++ b/rdagent/scenarios/data_science/proposal/exp_gen/select/submit.py
@@ -1,7 +1,6 @@
 import json
 import math
 import os
-import pickle
 import re
 import shutil
 import time
@@ -18,6 +17,7 @@ from rdagent.app.data_science.conf import DS_RD_SETTING
 from rdagent.components.coder.data_science.conf import get_ds_env
 from rdagent.core.experiment import FBWorkspace
 from rdagent.core.proposal import ExperimentFeedback, SOTAexpSelector, Trace
+from rdagent.core.serialization import load as secure_pickle_load
 from rdagent.core.utils import multiprocessing_wrapper
 from rdagent.log.storage import FileStorage
 from rdagent.log.utils import extract_json
@@ -730,7 +730,7 @@ def evaluate_one_trace(
                 sota_mle_score_paths = [i for i in log_path.rglob(f"Loop_{loop_id}/running/mle_score/**/*.pkl")]
                 if len(sota_mle_score_paths):
                     with sota_mle_score_paths[0].open("rb") as f:
-                        sota_mle_score = extract_json(pickle.load(f))
+                        sota_mle_score = extract_json(secure_pickle_load(f))
                         if sota_mle_score.get("any_medal", False):
                             pool_hit = True
                             break
@@ -762,7 +762,7 @@ def evaluate_one_trace(
         sota_mle_score_paths = [i for i in log_path.rglob(f"Loop_{loop_id}/running/mle_score/**/*.pkl")]
         if len(sota_mle_score_paths):
             with sota_mle_score_paths[0].open("rb") as f:
-                sota_mle_score = extract_json(pickle.load(f))
+                sota_mle_score = extract_json(secure_pickle_load(f))
                 hit = sota_mle_score.get("any_medal", False)
                 if hit:
                     if sota_mle_score["gold_medal"]:
@@ -822,7 +822,8 @@ def select_on_existing_trace(
                 if competition is not None and not competition in str(trace_pkl_path):
                     continue
                 sota_result = {}
-                trace = pickle.load(trace_pkl_path.open("rb"))
+                with trace_pkl_path.open("rb") as f:
+                    trace = secure_pickle_load(f)
                 try:
                     sota_loops_file = trace_folder / f"{trace_pkl_path.stem.split('_')[0]}_loops.json"
                     with open(sota_loops_file, "r") as f:

--- a/rdagent/scenarios/kaggle/experiment/scenario.py
+++ b/rdagent/scenarios/kaggle/experiment/scenario.py
@@ -1,6 +1,5 @@
 import io
 import json
-import pickle
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict
@@ -133,27 +132,18 @@ class KGScenario(Scenario):
     @property
     def source_data(self) -> str:
         data_folder = Path(KAGGLE_IMPLEMENT_SETTING.local_data_path) / self.competition
+        validation_cache = data_folder / "X_valid.parquet"
 
-        if not (data_folder / "X_valid.pkl").exists():
+        if validation_cache.exists():
+            X_valid = pd.read_parquet(validation_cache)
+        else:
             preprocess_experiment = KGFactorExperiment([])
-            (
-                X_train,
-                X_valid,
-                y_train,
-                y_valid,
-                X_test,
-                *others,
-            ) = preprocess_experiment.experiment_workspace.generate_preprocess_data()
+            preprocess_data = preprocess_experiment.experiment_workspace.generate_preprocess_data()
+            X_valid = preprocess_data[1]
 
-            data_folder.mkdir(exist_ok=True, parents=True)
-            pickle.dump(X_train, open(data_folder / "X_train.pkl", "wb"))
-            pickle.dump(X_valid, open(data_folder / "X_valid.pkl", "wb"))
-            pickle.dump(y_train, open(data_folder / "y_train.pkl", "wb"))
-            pickle.dump(y_valid, open(data_folder / "y_valid.pkl", "wb"))
-            pickle.dump(X_test, open(data_folder / "X_test.pkl", "wb"))
-            pickle.dump(others, open(data_folder / "others.pkl", "wb"))
-
-        X_valid = pd.read_pickle(data_folder / "X_valid.pkl")
+            if isinstance(X_valid, pd.DataFrame):
+                data_folder.mkdir(exist_ok=True, parents=True)
+                X_valid.to_parquet(validation_cache)
         # TODO: Hardcoded for now, need to be fixed
         if self.competition == "feedback-prize-english-language-learning":
             return "This is a sparse matrix of descriptive text."

--- a/rdagent/scenarios/kaggle/experiment/workspace.py
+++ b/rdagent/scenarios/kaggle/experiment/workspace.py
@@ -8,20 +8,16 @@ import pandas as pd
 from rdagent.app.kaggle.conf import KAGGLE_IMPLEMENT_SETTING
 from rdagent.core.experiment import FBWorkspace
 from rdagent.log import rdagent_logger as logger
+from rdagent.utils.artifact_transport import ARTIFACT_DUMP_CODE
 from rdagent.utils.env import KGDockerEnv
 
-KG_FEATURE_PREPROCESS_SCRIPT = """import pickle
+KG_FEATURE_PREPROCESS_SCRIPT = ARTIFACT_DUMP_CODE + """
 
 from fea_share_preprocess import preprocess_script
 
 X_train, X_valid, y_train, y_valid, X_test, *others = preprocess_script()
 
-pickle.dump(X_train, open("X_train.pkl", "wb"))
-pickle.dump(X_valid, open("X_valid.pkl", "wb"))
-pickle.dump(y_train, open("y_train.pkl", "wb"))
-pickle.dump(y_valid, open("y_valid.pkl", "wb"))
-pickle.dump(X_test, open("X_test.pkl", "wb"))
-pickle.dump(others, open("others.pkl", "wb"))
+dump_safe_artifacts([X_train, X_valid, y_train, y_valid, X_test, others])
 """
 
 
@@ -49,12 +45,7 @@ class KGFBWorkspace(FBWorkspace):
             code=KG_FEATURE_PREPROCESS_SCRIPT,
             local_path=str(self.workspace_path),
             dump_file_names=[
-                "X_train.pkl",
-                "X_valid.pkl",
-                "y_train.pkl",
-                "y_valid.pkl",
-                "X_test.pkl",
-                "others.pkl",
+                "rdagent_artifacts/manifest.json",
             ],
             running_extra_volume=(
                 {KAGGLE_IMPLEMENT_SETTING.local_data_path + "/" + KAGGLE_IMPLEMENT_SETTING.competition: "/kaggle/input"}

--- a/rdagent/scenarios/kaggle/knowledge_management/vector_base.py
+++ b/rdagent/scenarios/kaggle/knowledge_management/vector_base.py
@@ -5,6 +5,7 @@ from typing import List, Union
 import pandas as pd
 
 from rdagent.components.knowledge_management.vector_base import Document, PDVectorBase
+from rdagent.core.serialization import dump as secure_pickle_dump
 from rdagent.log import rdagent_logger as logger
 from rdagent.oai.llm_utils import APIBackend
 from rdagent.scenarios.kaggle.knowledge_management.extract_knowledge import (
@@ -288,7 +289,8 @@ class KaggleExperienceBase(PDVectorBase):
         vector_df_path: str or Path
             Path to save the vector DataFrame.
         """
-        self.vector_df.to_pickle(vector_df_path)
+        with Path(vector_df_path).open("wb") as f:
+            secure_pickle_dump({"vector_df": self.vector_df}, f)
         logger.info(f"Vector DataFrame saved to {vector_df_path}")
 
 

--- a/rdagent/scenarios/qlib/experiment/factor_template/read_exp_res.py
+++ b/rdagent/scenarios/qlib/experiment/factor_template/read_exp_res.py
@@ -52,4 +52,4 @@ else:
     print(f"Output has been saved to {output_path}")
 
     ret_data_frame = latest_recorder.load_object("portfolio_analysis/report_normal_1day.pkl")
-    ret_data_frame.to_pickle("ret.pkl")
+ret_data_frame.to_parquet("ret.parquet")

--- a/rdagent/scenarios/qlib/experiment/model_template/read_exp_res.py
+++ b/rdagent/scenarios/qlib/experiment/model_template/read_exp_res.py
@@ -52,4 +52,4 @@ else:
     print(f"Output has been saved to {output_path}")
 
     ret_data_frame = latest_recorder.load_object("portfolio_analysis/report_normal_1day.pkl")
-    ret_data_frame.to_pickle("ret.pkl")
+ret_data_frame.to_parquet("ret.parquet")

--- a/rdagent/scenarios/qlib/experiment/workspace.py
+++ b/rdagent/scenarios/qlib/experiment/workspace.py
@@ -39,9 +39,9 @@ class QlibFBWorkspace(FBWorkspace):
             env=run_env,
         )
 
-        quantitative_backtesting_chart_path = self.workspace_path / "ret.pkl"
+        quantitative_backtesting_chart_path = self.workspace_path / "ret.parquet"
         if quantitative_backtesting_chart_path.exists():
-            ret_df = pd.read_pickle(quantitative_backtesting_chart_path)
+            ret_df = pd.read_parquet(quantitative_backtesting_chart_path)
             logger.log_object(ret_df, tag="Quantitative Backtesting Chart")
         else:
             logger.error("No result file found.")

--- a/rdagent/utils/artifact_transport.py
+++ b/rdagent/utils/artifact_transport.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-import pandas as pd
-from sklearn.preprocessing import LabelEncoder
+import pandas as pd  # type: ignore[import-untyped]
+from sklearn.preprocessing import LabelEncoder  # type: ignore[import-untyped]
 
 ARTIFACT_DUMP_CODE = r"""
 import json

--- a/rdagent/utils/artifact_transport.py
+++ b/rdagent/utils/artifact_transport.py
@@ -1,0 +1,136 @@
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import LabelEncoder
+
+ARTIFACT_DUMP_CODE = r"""
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import LabelEncoder
+
+
+def _dump_safe_artifact(value, root, name):
+    if isinstance(value, pd.DataFrame):
+        file_name = f"{name}.parquet"
+        value.to_parquet(root / file_name)
+        return {"type": "dataframe", "file": file_name}
+    if isinstance(value, pd.Series):
+        file_name = f"{name}.parquet"
+        value.to_frame("__rdagent_value__").to_parquet(root / file_name)
+        series_name = (
+            value.name if value.name is None or isinstance(value.name, (bool, int, float, str)) else str(value.name)
+        )
+        return {"type": "series", "file": file_name, "name": series_name}
+    if isinstance(value, pd.Index):
+        file_name = f"{name}.parquet"
+        value.to_series(index=range(len(value)), name="__rdagent_value__").to_frame().to_parquet(root / file_name)
+        index_name = (
+            value.name if value.name is None or isinstance(value.name, (bool, int, float, str)) else str(value.name)
+        )
+        return {"type": "index", "file": file_name, "name": index_name}
+    if isinstance(value, np.ndarray):
+        if value.dtype.hasobject:
+            return {"type": "ndarray_json", "value": value.tolist()}
+        file_name = f"{name}.npy"
+        np.save(root / file_name, value, allow_pickle=False)
+        return {"type": "ndarray", "file": file_name}
+    if isinstance(value, LabelEncoder):
+        return {"type": "label_encoder", "classes": value.classes_.tolist()}
+    if isinstance(value, np.generic):
+        return {"type": "scalar", "value": value.item()}
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return {"type": "scalar", "value": value}
+    if isinstance(value, (list, tuple)):
+        return {
+            "type": "tuple" if isinstance(value, tuple) else "list",
+            "items": [_dump_safe_artifact(item, root, f"{name}_{index}") for index, item in enumerate(value)],
+        }
+    if isinstance(value, dict):
+        return {
+            "type": "dict",
+            "items": [
+                [_dump_safe_artifact(key, root, f"{name}_key_{index}"),
+                 _dump_safe_artifact(item, root, f"{name}_value_{index}")]
+                for index, (key, item) in enumerate(value.items())
+            ],
+        }
+    raise TypeError(f"Unsupported result artifact type: {type(value).__module__}.{type(value).__qualname__}")
+
+
+def dump_safe_artifacts(values, output_folder="rdagent_artifacts"):
+    root = Path(output_folder)
+    root.mkdir(parents=True, exist_ok=True)
+    manifest = [_dump_safe_artifact(value, root, f"artifact_{index}") for index, value in enumerate(values)]
+    (root / "manifest.json").write_text(json.dumps(manifest))
+"""
+
+
+def _artifact_path(root: Path, file_name: str) -> Path:
+    path = (root / file_name).resolve()
+    try:
+        path.relative_to(root)
+    except ValueError as exc:
+        message = f"Artifact file escapes bundle directory: {file_name}"
+        raise ValueError(message) from exc
+    return path
+
+
+def _load_node(node: dict[str, Any], root: Path) -> Any:  # noqa: PLR0911
+    artifact_type = node["type"]
+    if artifact_type == "dataframe":
+        return pd.read_parquet(_artifact_path(root, node["file"]))
+    if artifact_type == "series":
+        series = pd.read_parquet(_artifact_path(root, node["file"]))["__rdagent_value__"]
+        series.name = node.get("name")
+        return series
+    if artifact_type == "index":
+        values = pd.read_parquet(_artifact_path(root, node["file"]))["__rdagent_value__"]
+        return pd.Index(values, name=node.get("name"))
+    if artifact_type == "ndarray":
+        return np.load(_artifact_path(root, node["file"]), allow_pickle=False)
+    if artifact_type == "ndarray_json":
+        return np.asarray(node["value"])
+    if artifact_type == "label_encoder":
+        encoder = LabelEncoder()
+        encoder.classes_ = np.asarray(node["classes"])
+        return encoder
+    if artifact_type == "scalar":
+        return node.get("value")
+    if artifact_type in {"list", "tuple"}:
+        values = [_load_node(item, root) for item in node["items"]]
+        return tuple(values) if artifact_type == "tuple" else values
+    if artifact_type == "dict":
+        return {_load_node(key, root): _load_node(value, root) for key, value in node["items"]}
+    message = f"Unsupported result artifact type: {artifact_type}"
+    raise ValueError(message)
+
+
+def load_artifact_bundle(manifest_path: str | Path) -> list[Any]:
+    path = Path(manifest_path)
+    manifest = json.loads(path.read_text())
+    if not isinstance(manifest, list):
+        message = "Artifact manifest must contain a list"
+        raise TypeError(message)
+    return [_load_node(node, path.parent) for node in manifest]
+
+
+def load_result_artifact(path: str | Path) -> list[Any]:
+    artifact_path = Path(path)
+    if artifact_path.name == "manifest.json" and artifact_path.parent.name == "rdagent_artifacts":
+        return load_artifact_bundle(artifact_path)
+    if artifact_path.suffix == ".json":
+        return [json.loads(artifact_path.read_text())]
+    if artifact_path.suffix == ".txt":
+        return [artifact_path.read_text()]
+    if artifact_path.suffix == ".npy":
+        return [np.load(artifact_path, allow_pickle=False)]
+    if artifact_path.suffix == ".parquet":
+        return [pd.read_parquet(artifact_path)]
+    message = f"Unsafe result artifact format: {artifact_path.suffix}"
+    raise ValueError(message)

--- a/rdagent/utils/env.py
+++ b/rdagent/utils/env.py
@@ -10,7 +10,6 @@ Tries to create uniform environment for the agent to run;
 import contextlib
 import json
 import os
-import pickle
 import re
 import select
 import shutil
@@ -55,6 +54,9 @@ from tqdm import tqdm
 
 from rdagent.core.conf import ExtendedBaseSettings
 from rdagent.core.experiment import RD_AGENT_SETTINGS
+from rdagent.core.serialization import UntrustedArtifactError
+from rdagent.core.serialization import dump as secure_pickle_dump
+from rdagent.core.serialization import load as secure_pickle_load
 from rdagent.core.utils import cache_with_pickle
 from rdagent.log import rdagent_logger as logger
 from rdagent.oai.llm_utils import md5_hash
@@ -494,13 +496,22 @@ class Env(Generic[ASpecificEnvConf]):
             # + json.dumps(data_key)
         )
         if Path(target_folder / f"{key}.pkl").exists() and Path(target_folder / f"{key}.zip").exists():
-            with open(target_folder / f"{key}.pkl", "rb") as f:
-                ret = pickle.load(f)
-            self.unzip_a_file_into_a_folder(str(target_folder / f"{key}.zip"), local_path, cache_files_to_extract)
+            try:
+                with open(target_folder / f"{key}.pkl", "rb") as f:
+                    ret = secure_pickle_load(f)
+            except UntrustedArtifactError:
+                Path(target_folder / f"{key}.pkl").unlink(missing_ok=True)
+                Path(target_folder / f"{key}.zip").unlink(missing_ok=True)
+                ret = self.__run_with_retry(entry, local_path, env, running_extra_volume)
+                with open(target_folder / f"{key}.pkl", "wb") as f:
+                    secure_pickle_dump(ret, f)
+                self.zip_a_folder_into_a_file(local_path, str(target_folder / f"{key}.zip"))
+            else:
+                self.unzip_a_file_into_a_folder(str(target_folder / f"{key}.zip"), local_path, cache_files_to_extract)
         else:
             ret = self.__run_with_retry(entry, local_path, env, running_extra_volume)
             with open(target_folder / f"{key}.pkl", "wb") as f:
-                pickle.dump(ret, f)
+                secure_pickle_dump(ret, f)
             self.zip_a_folder_into_a_file(local_path, str(target_folder / f"{key}.zip"))
         return cast(EnvResult, ret)
 
@@ -546,6 +557,8 @@ class Env(Generic[ASpecificEnvConf]):
         """
         Dump the code into the local path and run the code.
         """
+        from rdagent.utils.artifact_transport import load_result_artifact
+
         random_file_name = f"{uuid.uuid4()}.py" if code_dump_file_py_name is None else f"{code_dump_file_py_name}.py"
         with open(os.path.join(local_path, random_file_name), "w") as f:
             f.write(code)
@@ -554,11 +567,14 @@ class Env(Generic[ASpecificEnvConf]):
         results = []
         os.remove(os.path.join(local_path, random_file_name))
         for name in dump_file_names:
-            if os.path.exists(os.path.join(local_path, f"{name}")):
-                results.append(pickle.load(open(os.path.join(local_path, f"{name}"), "rb")))
-                os.remove(os.path.join(local_path, f"{name}"))
-            else:
+            result_path = Path(local_path) / name
+            if not result_path.exists():
                 return log_output, []
+            results.extend(load_result_artifact(result_path))
+            if result_path.name == "manifest.json" and result_path.parent.name == "rdagent_artifacts":
+                shutil.rmtree(result_path.parent)
+                continue
+            result_path.unlink()
         return log_output, results
 
     def refresh_env(self) -> None:

--- a/rdagent/utils/workflow/loop.py
+++ b/rdagent/utils/workflow/loop.py
@@ -13,7 +13,6 @@ import concurrent.futures
 import copy
 import multiprocessing.queues
 import os
-import pickle
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -24,6 +23,8 @@ import psutil
 from tqdm.auto import tqdm
 
 from rdagent.core.conf import RD_AGENT_SETTINGS
+from rdagent.core.serialization import dump as secure_pickle_dump
+from rdagent.core.serialization import load as secure_pickle_load
 from rdagent.log import rdagent_logger as logger
 from rdagent.log.conf import LOG_SETTINGS
 from rdagent.log.timer import RD_Agent_TIMER_wrapper, RDAgentTimer
@@ -429,7 +430,7 @@ class LoopBase:
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("wb") as f:
-            pickle.dump(self, f)
+            secure_pickle_dump(self, f)
 
     def truncate_session_folder(self, li: int, si: int) -> None:
         """
@@ -496,7 +497,7 @@ class LoopBase:
             session_folder = path.parent.parent
 
         with path.open("rb") as f:
-            session = cast(LoopBase, pickle.load(f))
+            session = cast(LoopBase, secure_pickle_load(f))
 
         # set session folder
         if checkout:

--- a/test/core/test_serialization.py
+++ b/test/core/test_serialization.py
@@ -1,0 +1,124 @@
+import pickle
+from pathlib import Path
+
+import dill
+import pytest
+
+from rdagent.core.conf import RD_AGENT_SETTINGS
+from rdagent.core.serialization import UntrustedArtifactError, dumps, loads
+from rdagent.core.utils import cache_with_pickle
+from rdagent.log.storage import FileStorage
+
+KEY_FILE_MODE = 0o600
+EXPECTED_INCREMENTED_VALUE = 2
+
+
+@pytest.fixture
+def signing_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    key_path = tmp_path / "artifact.key"
+    monkeypatch.setattr(RD_AGENT_SETTINGS, "artifact_signing_key", "")
+    monkeypatch.setattr(RD_AGENT_SETTINGS, "artifact_signing_key_path", key_path)
+    monkeypatch.setattr(RD_AGENT_SETTINGS, "allow_unsafe_legacy_pickle", False)
+    return key_path
+
+
+@pytest.mark.offline
+def test_signed_pickle_round_trip(signing_key: Path) -> None:
+    value = {"score": 0.75, "items": [1, 2, 3]}
+    assert loads(dumps(value)) == value
+    assert signing_key.stat().st_mode & 0o777 == KEY_FILE_MODE
+    assert "artifact_signing_key" not in RD_AGENT_SETTINGS.model_dump()
+
+
+@pytest.mark.offline
+def test_configured_signing_key_does_not_create_key_file(signing_key: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(RD_AGENT_SETTINGS, "artifact_signing_key", "shared-secret-with-sufficient-entropy")
+    assert loads(dumps({"shared": True})) == {"shared": True}
+    assert not signing_key.exists()
+
+
+@pytest.mark.offline
+def test_short_configured_signing_key_is_rejected(signing_key: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    assert signing_key.parent.exists()
+    monkeypatch.setattr(RD_AGENT_SETTINGS, "artifact_signing_key", "too-short")
+    with pytest.raises(ValueError, match="at least 32 bytes"):
+        dumps({"shared": True})
+
+
+@pytest.mark.offline
+def test_signed_dill_round_trip(signing_key: Path) -> None:
+    assert signing_key.parent.exists()
+
+    def increment(item: int) -> int:
+        return item + 1
+
+    restored = loads(dumps(increment, serializer=dill), serializer=dill)
+    assert restored(1) == EXPECTED_INCREMENTED_VALUE
+
+
+@pytest.mark.offline
+def test_modified_signed_pickle_is_rejected(signing_key: Path) -> None:
+    assert signing_key.parent.exists()
+    payload = bytearray(dumps({"safe": True}))
+    payload[-1] ^= 1
+    with pytest.raises(UntrustedArtifactError, match="signature"):
+        loads(bytes(payload))
+
+
+@pytest.mark.offline
+def test_unsigned_pickle_is_rejected_before_deserialization(signing_key: Path, tmp_path: Path) -> None:
+    assert signing_key.parent.exists()
+    marker = tmp_path / "executed"
+
+    class Payload:
+        def __reduce__(self) -> tuple:
+            return marker.touch, ()
+
+    payload = pickle.dumps(Payload())
+    with pytest.raises(UntrustedArtifactError, match="Unsigned"):
+        loads(payload)
+    assert not marker.exists()
+
+
+@pytest.mark.offline
+def test_legacy_pickle_requires_explicit_opt_in(signing_key: Path) -> None:
+    assert signing_key.parent.exists()
+    payload = pickle.dumps({"legacy": True})
+    assert loads(payload, allow_unsafe_legacy=True) == {"legacy": True}
+
+
+@pytest.mark.offline
+def test_unsigned_cache_is_treated_as_cache_miss(
+    signing_key: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert signing_key.parent.exists()
+    monkeypatch.setattr(RD_AGENT_SETTINGS, "pickle_cache_folder_path_str", str(tmp_path / "cache"))
+    calls = 0
+
+    @cache_with_pickle(lambda: "fixed-key", force=True)
+    def compute() -> str:
+        nonlocal calls
+        calls += 1
+        return "fresh"
+
+    cache_file = tmp_path / "cache" / f"{compute.__module__}.{compute.__name__}" / "fixed-key.pkl"
+    cache_file.parent.mkdir(parents=True)
+    cache_file.write_bytes(pickle.dumps("attacker-controlled"))
+
+    assert compute() == "fresh"
+    assert calls == 1
+    assert loads(cache_file.read_bytes()) == "fresh"
+
+
+@pytest.mark.offline
+def test_file_storage_writes_and_reads_signed_messages(signing_key: Path, tmp_path: Path) -> None:
+    assert signing_key.parent.exists()
+    storage = FileStorage(tmp_path / "trace")
+    artifact_path = storage.log({"message": "safe"}, tag="record.test")
+
+    assert isinstance(artifact_path, Path)
+    assert artifact_path.read_bytes().startswith(b"RDAGENT_SIGNED_PICKLE_V1")
+    messages = list(storage.iter_msg(tag="record.test"))
+    assert [message.content for message in messages] == [{"message": "safe"}]

--- a/test/utils/test_artifact_transport.py
+++ b/test/utils/test_artifact_transport.py
@@ -1,0 +1,53 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.preprocessing import LabelEncoder
+
+from rdagent.utils.artifact_transport import (
+    ARTIFACT_DUMP_CODE,
+    load_artifact_bundle,
+    load_result_artifact,
+)
+
+
+@pytest.mark.offline
+def test_safe_artifact_bundle_round_trip(tmp_path: Path) -> None:
+    namespace: dict = {}
+    exec(ARTIFACT_DUMP_CODE, namespace)  # noqa: S102
+    frame = pd.DataFrame({"feature": [1.0, 2.0]}, index=[10, 20])
+    series = pd.Series([3, 4], name="target", index=[10, 20])
+    array = np.asarray([[1, 2], [3, 4]])
+    encoder = LabelEncoder().fit(["a", "b"])
+    values = [frame, series, array, [encoder, "id"]]
+
+    namespace["dump_safe_artifacts"](values, tmp_path / "rdagent_artifacts")
+    restored = load_artifact_bundle(tmp_path / "rdagent_artifacts" / "manifest.json")
+
+    pd.testing.assert_frame_equal(restored[0], frame)
+    pd.testing.assert_series_equal(restored[1], series)
+    np.testing.assert_array_equal(restored[2], array)
+    np.testing.assert_array_equal(restored[3][0].classes_, encoder.classes_)
+    assert restored[3][1] == "id"
+
+
+@pytest.mark.offline
+def test_artifact_bundle_rejects_file_path_escape(tmp_path: Path) -> None:
+    bundle = tmp_path / "rdagent_artifacts"
+    bundle.mkdir()
+    manifest = [{"type": "ndarray", "file": "../outside.npy"}]
+    (bundle / "manifest.json").write_text(json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="escapes"):
+        load_artifact_bundle(bundle / "manifest.json")
+
+
+@pytest.mark.offline
+def test_result_loader_rejects_pickle(tmp_path: Path) -> None:
+    result_path = tmp_path / "result.pkl"
+    result_path.write_bytes(b"not deserialized")
+
+    with pytest.raises(ValueError, match="Unsafe result artifact format"):
+        load_result_artifact(result_path)


### PR DESCRIPTION
## Summary

- add an HMAC-signed pickle envelope and verify signatures before any host-side pickle/dill deserialization
- preserve existing Python object/session behavior while rejecting unsigned legacy artifacts by default
- generate a per-installation 256-bit signing key, or accept a shared `ARTIFACT_SIGNING_KEY` of at least 32 bytes
- keep the signing secret out of settings dumps
- treat unsigned legacy cache entries as cache misses instead of executing them
- replace container-to-host pickle results with typed JSON/Parquet/NPY/text artifact transport
- move Qlib tabular backtest results and Kaggle validation cache data to Parquet
- update log, session, knowledge-base, summary, benchmark, and UI readers/writers to use verified serialization
- document signing-key management, shared-host configuration, legacy migration, and safe result formats

## Compatibility

Complex sessions and knowledge objects keep their current Python types; this avoids a broad object-model rewrite.

Unsigned existing logs, sessions, and knowledge bases are rejected by default. Operators can temporarily set `ALLOW_UNSAFE_LEGACY_PICKLE=true` only when importing fully trusted legacy artifacts. Existing unsigned caches are automatically discarded and rebuilt.

For shared filesystems or multiple hosts, configure the same `ARTIFACT_SIGNING_KEY` on every trusted RD-Agent process. Without it, a local key is created at `~/.rdagent/artifact_signing.key` with mode `0600`.

## Security impact

Attacker-created or modified pickle files are rejected before `pickle.loads`/`dill.loads` is reached. Container-generated outputs are no longer deserialized as pickle on the host.

## Validation

This branch is rebased onto `main` after #1468 and #1469. Combined validation confirms that the web, execution/archive/workspace, and serialization protections coexist.

- 46 focused security tests and 12 subtests pass
- full offline suite: 44 passed, 112 deselected, and 304 subtests passed
- 301+ import subtests pass
- Sphinx documentation build with `-W` passes
- compileall and diff checks pass
- end-to-end Factor, Model, and Quant validation completed with two successful loops and non-empty Qlib artifacts/metrics
