### PR TITLE
fix: handle missing queried knowledge in model strategy

### DIFF
--- a/rdagent/components/coder/data_science/model/__init__.py
+++ b/rdagent/components/coder/data_science/model/__init__.py
@@ -46,7 +46,7 @@ class ModelMultiProcessEvolvingStrategy(MultiProcessEvolvingStrategy):
         queried_former_failed_knowledge = (
             queried_knowledge.task_to_former_failed_traces[model_information_str]
             if queried_knowledge is not None
-            else []
+            else ([], None)
         )
         queried_former_failed_knowledge = (
             [

--- a/test/scenarios/data_science/test_model_strategy_none_knowledge.py
+++ b/test/scenarios/data_science/test_model_strategy_none_knowledge.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+
+import pytest
+
+import rdagent.components.coder.data_science.model as model_module
+from rdagent.components.coder.data_science.model import (
+    ModelMultiProcessEvolvingStrategy,
+)
+
+pytestmark = pytest.mark.offline
+
+
+def test_model_strategy_accepts_none_queried_knowledge(monkeypatch):
+    class FakeTemplate:
+        def r(self, *args, **kwargs):
+            return "prompt"
+
+    monkeypatch.setattr(model_module, "T", lambda *args, **kwargs: FakeTemplate())
+    monkeypatch.setattr(model_module.DS_RD_SETTING, "spec_enabled", True)
+    monkeypatch.setattr(
+        model_module.PythonBatchEditOut,
+        "extract_output",
+        lambda *args, **kwargs: {"model_generated.py": "new code"},
+    )
+
+    class FakeBackend:
+        def build_messages_and_create_chat_completion(self, **kwargs):
+            return "response"
+
+    monkeypatch.setattr(model_module, "APIBackend", FakeBackend)
+
+    strategy = object.__new__(ModelMultiProcessEvolvingStrategy)
+    strategy.scen = SimpleNamespace(get_scenario_all_desc=lambda eda_output=None: "scenario")
+
+    target_task = SimpleNamespace(
+        name="model_1",
+        get_task_information=lambda: "model task",
+    )
+
+    class FakeWorkspace:
+        file_dict = {
+            "model_1.py": "old code",
+            "feature.py": "feature code",
+            "load_data.py": "loader code",
+            "spec/model.md": "model spec",
+        }
+
+        def get_codes(self, pattern):
+            return {"model_1.py": "old code"}
+
+    result = strategy.implement_one_task(
+        target_task=target_task,
+        queried_knowledge=None,
+        workspace=FakeWorkspace(),
+    )
+
+    assert result == {"model_1.py": "new code"}


### PR DESCRIPTION
## Description

Use the queried-knowledge layer's shape-compatible `([], None)` empty value when `queried_knowledge` is omitted from `ModelMultiProcessEvolvingStrategy.implement_one_task`.

This also adds an offline regression test that exercises the direct strategy call without making model or network requests.

## Motivation and Context

Fixes #1461.

The method declares `queried_knowledge` as optional, but its `None` branch previously returned an empty list and then immediately indexed it as a two-item failed-knowledge tuple. Direct callers therefore received an incidental `IndexError` before prompt construction or backend invocation.

## How Has This Been Tested?

- [ ] If you are adding a new feature, test on your own test scripts.

- `python -m pytest -p no:cacheprovider -q test/scenarios/data_science/test_model_strategy_none_knowledge.py` (1 passed)
- `make test-offline` (3 tests and 299 subtests passed)
- `make lint`
- `make docs-gen`
- `make build`

## Screenshots of Test Results (if appropriate):

Not applicable; this is a deterministic unit-level regression.

## Types of changes

- [x] Fix bugs
- [ ] Add new feature
- [ ] Update documentation


<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1472.org.readthedocs.build/en/1472/

<!-- readthedocs-preview RDAgent end -->