### PR TITLE
Reject file keys that escape the workspace in inject_files

### DIFF
--- a/rdagent/core/experiment.py
+++ b/rdagent/core/experiment.py
@@ -231,8 +231,12 @@ class FBWorkspace(Workspace):
         }
         """
         self.prepare()
+        workspace_root = self.workspace_path.resolve()
         for k, v in files.items():
-            target_file_path = self.workspace_path / k  # Define target_file_path before using it
+            target_file_path = (workspace_root / k).resolve()
+            if not target_file_path.is_relative_to(workspace_root):
+                escape_msg = f"File path escapes workspace: {k}"
+                raise ValueError(escape_msg)
             if v == self.DEL_KEY:  # Use self.DEL_KEY to access the class variable
                 if target_file_path.exists():
                     target_file_path.unlink()  # Unlink the file if it exists

--- a/test/utils/test_ws.py
+++ b/test/utils/test_ws.py
@@ -74,3 +74,35 @@ class TestFBWorkspace(unittest.TestCase):
         ws.create_ws_ckp()
         ws.recover_ws_ckp()
         self.assertFalse((ws.workspace_path / "large.bin").exists())
+
+    def test_inject_files_rejects_paths_outside_workspace(self) -> None:
+        """
+        `inject_files` must never create, overwrite, or delete a file outside
+        `workspace_path`, for either the write or the DEL_KEY delete branch.
+        """
+        ws = FBWorkspace()
+        ws.workspace_path = self.tmp_path / "ws"
+        ws.prepare()
+
+        ws.inject_files(**{"file.py": "a", "subdir/file.py": "b"})
+        self.assertEqual((ws.workspace_path / "file.py").read_text(), "a")
+        self.assertEqual((ws.workspace_path / "subdir" / "file.py").read_text(), "b")
+        self.assertEqual(ws.file_dict["file.py"], "a")
+
+        outside = self.tmp_path / "escape.txt"
+        with self.assertRaises(ValueError):
+            ws.inject_files(**{"../escape.txt": "escaped"})
+        self.assertFalse(outside.exists())
+        self.assertNotIn("../escape.txt", ws.file_dict)
+
+        absolute_outside = self.tmp_path / "abs_escape.txt"
+        with self.assertRaises(ValueError):
+            ws.inject_files(**{str(absolute_outside): "escaped"})
+        self.assertFalse(absolute_outside.exists())
+
+        preexisting_outside = self.tmp_path / "preexisting.txt"
+        preexisting_outside.write_text("still here")
+        with self.assertRaises(ValueError):
+            ws.inject_files(**{"../preexisting.txt": FBWorkspace.DEL_KEY})
+        self.assertTrue(preexisting_outside.exists())
+        self.assertEqual(preexisting_outside.read_text(), "still here")


### PR DESCRIPTION
Fixes #1473

`FBWorkspace.inject_files` joined the caller's file keys directly onto
`workspace_path` and wrote/deleted the result with no containment
check, so a key such as `"../escape.txt"` (or an absolute path)
resolved to a location outside the workspace.

Resolves the workspace root once, resolves each candidate path against
it, and raises `ValueError` before either the write or the delete
branch runs if the resolved path is not inside the workspace root.

Added `test_inject_files_rejects_paths_outside_workspace` to the
existing `test/utils/test_ws.py` (rather than a new top-level test
file) since that is already this class's real home. It covers ordinary
and nested relative files still working, a `../` key, an absolute-path
key, and the `DEL_KEY` delete branch against a file that already
exists outside the workspace.

Verified: the new test fails with `AssertionError: ValueError not
raised` against the code on `main` (reverted the fix locally, kept the
test, reran it) and passes with the fix applied. `test/utils/test_ws.py`
(2 tests, including the pre-existing checkpoint-roundtrip test) passes
in full: `2 passed in 0.04s`. `ruff check` on both changed files is
clean relative to `main` — the only pre-existing lint items in
`test_ws.py` (unittest-style assertions, `os.readlink`) are unrelated
and already present before this change, left untouched.

Not in scope here: `FBWorkspace.remove_files` has the identical
`self.workspace_path / file_name` pattern with no containment check.
Flagging it since it's the same root cause, but leaving it out of this
PR since the issue is scoped to `inject_files` — happy to send a
follow-up if that's wanted.

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1476.org.readthedocs.build/en/1476/

<!-- readthedocs-preview RDAgent end -->