### PR TITLE
ci: upgrade release actions to Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,19 +14,19 @@ jobs:
     steps:
       - name: Release please
         id: release_please
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           # The current PAT (personal access token) was created on 2024-08-05,
           # since the maximum validity of PAT is 1 year, you need to change the PAT before 2025-08-05.
           token: ${{ secrets.PAT }}
           release-type: simple
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: ${{ steps.release_please.outputs.release_created }}
         with:
           fetch-depth: 0
       - name: Set up Python
         if: ${{ steps.release_please.outputs.release_created }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           cache: pip
           python-version: '3.10'


### PR DESCRIPTION
## Summary

- upgrade `googleapis/release-please-action` from v4 to v5
- upgrade `actions/checkout` from v4 to v5
- upgrade `actions/setup-python` from v5 to v6

All three updated action versions declare the Node 24 runtime. No release behavior, permissions, Python version, or publishing commands are changed.

## Validation

- parsed `.github/workflows/release.yml` with PyYAML
- verified the three expected `uses` values
- `git diff --check` passes

## Important

This removes the Node 20 deprecation warning, but it does **not** fix the existing `release-please failed: Bad credentials` error. The repository secret used as `secrets.PAT` must still be rotated or replaced separately.

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1477.org.readthedocs.build/en/1477/

<!-- readthedocs-preview RDAgent end -->