### PR TITLE
ci: use GitHub token for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,15 @@ jobs:
   release_and_publish:
     permissions:
       contents: write
-      pull-requests: read
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Release please
         id: release_please
         uses: googleapis/release-please-action@v5
         with:
-          # The current PAT (personal access token) was created on 2024-08-05,
-          # since the maximum validity of PAT is 1 year, you need to change the PAT before 2025-08-05.
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           release-type: simple
       - uses: actions/checkout@v5
         if: ${{ steps.release_please.outputs.release_created }}


### PR DESCRIPTION
## Summary

- replace the expired repository `PAT` secret with the built-in `GITHUB_TOKEN` for Release Please
- grant the release job `contents: write`, `pull-requests: write`, and `issues: write`
- remove the obsolete PAT creation and expiration comment

The PyPI publishing token and all build/upload steps remain unchanged.

## Validation

- parsed `.github/workflows/release.yml` with PyYAML
- verified the Release Please token expression and job permissions
- `git diff --check` passes

## Behavior change

GitHub suppresses new workflow runs caused by events created with `GITHUB_TOKEN`. As a result, a release PR, tag, or GitHub release created by Release Please may not automatically trigger other workflows. The Release workflow itself still performs the package build and PyPI upload when `release_created` is true.

If Release Please reports that GitHub Actions is not permitted to create pull requests, enable **Settings → Actions → General → Workflow permissions → Allow GitHub Actions to create and approve pull requests** for the repository.

<!-- readthedocs-preview RDAgent start -->
----
📚 Documentation preview 📚: https://RDAgent--1478.org.readthedocs.build/en/1478/

<!-- readthedocs-preview RDAgent end -->